### PR TITLE
Add --today flag to append for daily note rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.38] - 2026-04-04
+
+### Added
+
+- Add `--today` flag to `append` for daily note rotation: appends to today's matching note or creates a new one ([#49])
+
+[#49]: https://github.com/dreikanter/notescli/pull/49
+
 ## [0.1.37] - 2026-03-30
 
 ### Fixed
@@ -183,6 +191,11 @@
 - Add `new` and `new-todo` commands ([#2])
 - Add `--no-frontmatter` flag to `read` command ([#3], [#4])
 
+[0.1.38]: https://github.com/dreikanter/notescli/releases/tag/v0.1.38
+[0.1.37]: https://github.com/dreikanter/notescli/releases/tag/v0.1.37
+[0.1.36]: https://github.com/dreikanter/notescli/releases/tag/v0.1.36
+[0.1.35]: https://github.com/dreikanter/notescli/releases/tag/v0.1.35
+[0.1.34]: https://github.com/dreikanter/notescli/releases/tag/v0.1.34
 [0.1.32]: https://github.com/dreikanter/notescli/releases/tag/v0.1.32
 [0.1.31]: https://github.com/dreikanter/notescli/releases/tag/v0.1.31
 [0.1.30]: https://github.com/dreikanter/notescli/releases/tag/v0.1.30

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -34,6 +34,8 @@ var appendCmd = &cobra.Command{
 			return nil
 		}
 
+		todayDate := time.Now().Format("20060102")
+
 		noteType, _ := cmd.Flags().GetString("type")
 		slug, _ := cmd.Flags().GetString("slug")
 		tags, _ := cmd.Flags().GetStringSlice("tag")
@@ -58,8 +60,13 @@ var appendCmd = &cobra.Command{
 			return fmt.Errorf("--create and --today are mutually exclusive")
 		}
 
+		flagName := "create"
+		if today {
+			flagName = "today"
+		}
+
 		if canCreate && len(args) == 1 {
-			return fmt.Errorf("--%s cannot be combined with positional argument", map[bool]string{true: "today", false: "create"}[today])
+			return fmt.Errorf("--%s cannot be combined with positional argument", flagName)
 		}
 
 		if noteType != "" && !note.IsKnownType(noteType) {
@@ -99,7 +106,7 @@ var appendCmd = &cobra.Command{
 
 			needsCreate := false
 			if len(notes) > 0 {
-				if today && notes[0].Date != time.Now().Format("20060102") {
+				if today && notes[0].Date != todayDate {
 					needsCreate = true
 				} else {
 					targetPath = filepath.Join(root, notes[0].RelPath)
@@ -108,6 +115,10 @@ var appendCmd = &cobra.Command{
 				needsCreate = true
 			} else {
 				return fmt.Errorf("no notes found matching the given criteria")
+			}
+
+			if !needsCreate && (title != "" || description != "") {
+				fmt.Fprintln(cmd.ErrOrStderr(), "warning: --title and --description are ignored when appending to an existing note")
 			}
 
 			if needsCreate {
@@ -124,7 +135,7 @@ var appendCmd = &cobra.Command{
 				}
 			}
 		} else if canCreate {
-			return fmt.Errorf("--%s requires filter flags (--type, --slug, --tag)", map[bool]string{true: "today", false: "create"}[today])
+			return fmt.Errorf("--%s requires filter flags (--type, --slug, --tag)", flagName)
 		} else {
 			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag)")
 		}

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/dreikanter/notescli/note"
 	"github.com/spf13/cobra"
@@ -37,22 +38,28 @@ var appendCmd = &cobra.Command{
 		slug, _ := cmd.Flags().GetString("slug")
 		tags, _ := cmd.Flags().GetStringSlice("tag")
 		create, _ := cmd.Flags().GetBool("create")
+		today, _ := cmd.Flags().GetBool("today")
 		title, _ := cmd.Flags().GetString("title")
 		description, _ := cmd.Flags().GetString("description")
 
 		hasFilters := noteType != "" || slug != "" || len(tags) > 0
+		canCreate := create || today
 
-		if !create {
+		if !canCreate {
 			if title != "" {
-				return fmt.Errorf("--title requires --create")
+				return fmt.Errorf("--title requires --create or --today")
 			}
 			if description != "" {
-				return fmt.Errorf("--description requires --create")
+				return fmt.Errorf("--description requires --create or --today")
 			}
 		}
 
-		if create && len(args) == 1 {
-			return fmt.Errorf("--create cannot be combined with positional argument")
+		if create && today {
+			return fmt.Errorf("--create and --today are mutually exclusive")
+		}
+
+		if canCreate && len(args) == 1 {
+			return fmt.Errorf("--%s cannot be combined with positional argument", map[bool]string{true: "today", false: "create"}[today])
 		}
 
 		if noteType != "" && !note.IsKnownType(noteType) {
@@ -90,9 +97,20 @@ var appendCmd = &cobra.Command{
 				}
 			}
 
+			needsCreate := false
 			if len(notes) > 0 {
-				targetPath = filepath.Join(root, notes[0].RelPath)
-			} else if create {
+				if today && notes[0].Date != time.Now().Format("20060102") {
+					needsCreate = true
+				} else {
+					targetPath = filepath.Join(root, notes[0].RelPath)
+				}
+			} else if canCreate {
+				needsCreate = true
+			} else {
+				return fmt.Errorf("no notes found matching the given criteria")
+			}
+
+			if needsCreate {
 				targetPath, err = createNote(createNoteParams{
 					Root:        root,
 					Slug:        slug,
@@ -104,11 +122,9 @@ var appendCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-			} else {
-				return fmt.Errorf("no notes found matching the given criteria")
 			}
-		} else if create {
-			return fmt.Errorf("--create requires filter flags (--type, --slug, --tag)")
+		} else if canCreate {
+			return fmt.Errorf("--%s requires filter flags (--type, --slug, --tag)", map[bool]string{true: "today", false: "create"}[today])
 		} else {
 			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag)")
 		}
@@ -140,7 +156,8 @@ func init() {
 	appendCmd.Flags().String("slug", "", "filter by slug")
 	appendCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
 	appendCmd.Flags().Bool("create", false, "create note if no match found")
-	appendCmd.Flags().String("title", "", "title for frontmatter (requires --create)")
-	appendCmd.Flags().String("description", "", "description for frontmatter (requires --create)")
+	appendCmd.Flags().Bool("today", false, "append to today's note or create a new one")
+	appendCmd.Flags().String("title", "", "title for frontmatter (requires --create or --today)")
+	appendCmd.Flags().String("description", "", "description for frontmatter (requires --create or --today)")
 	rootCmd.AddCommand(appendCmd)
 }

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -162,7 +162,7 @@ var appendCmd = &cobra.Command{
 	},
 }
 
-func init() {
+func registerAppendFlags() {
 	appendCmd.Flags().String("type", "", "filter by note type")
 	appendCmd.Flags().String("slug", "", "filter by slug")
 	appendCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
@@ -170,5 +170,9 @@ func init() {
 	appendCmd.Flags().Bool("today", false, "append to today's note or create a new one")
 	appendCmd.Flags().String("title", "", "title for frontmatter (requires --create or --today)")
 	appendCmd.Flags().String("description", "", "description for frontmatter (requires --create or --today)")
+}
+
+func init() {
+	registerAppendFlags()
 	rootCmd.AddCommand(appendCmd)
 }

--- a/internal/cli/append_test.go
+++ b/internal/cli/append_test.go
@@ -42,13 +42,7 @@ func runAppend(t *testing.T, root string, stdin string, args ...string) (string,
 	t.Helper()
 
 	appendCmd.ResetFlags()
-	appendCmd.Flags().String("type", "", "filter by note type")
-	appendCmd.Flags().String("slug", "", "filter by slug")
-	appendCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
-	appendCmd.Flags().Bool("create", false, "create note if no match found")
-	appendCmd.Flags().Bool("today", false, "append to today's note or create a new one")
-	appendCmd.Flags().String("title", "", "title for frontmatter (requires --create or --today)")
-	appendCmd.Flags().String("description", "", "description for frontmatter (requires --create or --today)")
+	registerAppendFlags()
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)

--- a/internal/cli/append_test.go
+++ b/internal/cli/append_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // copyTestdata copies testdata into a temporary directory so append tests
@@ -45,8 +46,9 @@ func runAppend(t *testing.T, root string, stdin string, args ...string) (string,
 	appendCmd.Flags().String("slug", "", "filter by slug")
 	appendCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
 	appendCmd.Flags().Bool("create", false, "create note if no match found")
-	appendCmd.Flags().String("title", "", "title for frontmatter (requires --create)")
-	appendCmd.Flags().String("description", "", "description for frontmatter (requires --create)")
+	appendCmd.Flags().Bool("today", false, "append to today's note or create a new one")
+	appendCmd.Flags().String("title", "", "title for frontmatter (requires --create or --today)")
+	appendCmd.Flags().String("description", "", "description for frontmatter (requires --create or --today)")
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -418,5 +420,141 @@ func TestAppendCreateUnknownTypeErrors(t *testing.T) {
 	_, err := runAppend(t, root, "text", "--type", "invalid", "--create")
 	if err == nil {
 		t.Fatal("expected error for unknown note type, got nil")
+	}
+}
+
+func TestAppendTodayCreatesNewWhenOldDate(t *testing.T) {
+	root := copyTestdata(t)
+	// Existing meeting note is from 20260104, not today — should create new
+	out, err := runAppend(t, root, "today content", "--slug", "meeting", "--today")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT be the old file
+	oldFile := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
+	if out == oldFile {
+		t.Error("expected a new file, but got the old one")
+	}
+
+	// New file should contain today's date and the slug
+	base := filepath.Base(out)
+	today := time.Now().Format("20060102")
+	if !strings.HasPrefix(base, today) {
+		t.Errorf("expected filename to start with %s, got %s", today, base)
+	}
+	if !strings.Contains(base, "_meeting") {
+		t.Errorf("expected slug in filename, got %s", base)
+	}
+
+	data, _ := os.ReadFile(out)
+	if !strings.Contains(string(data), "today content") {
+		t.Error("appended content not found in created file")
+	}
+}
+
+func TestAppendTodayAppendsToExistingTodayNote(t *testing.T) {
+	root := copyTestdata(t)
+
+	// First create a note for today with the slug
+	firstOut, err := runAppend(t, root, "first entry", "--slug", "daily", "--today")
+	if err != nil {
+		t.Fatalf("unexpected error on first append: %v", err)
+	}
+
+	// Second append with --today should reuse the same file
+	secondOut, err := runAppend(t, root, "second entry", "--slug", "daily", "--today")
+	if err != nil {
+		t.Fatalf("unexpected error on second append: %v", err)
+	}
+
+	if firstOut != secondOut {
+		t.Errorf("expected same file, got %q and %q", firstOut, secondOut)
+	}
+
+	data, _ := os.ReadFile(firstOut)
+	content := string(data)
+	if !strings.Contains(content, "first entry") {
+		t.Error("first entry not found")
+	}
+	if !strings.Contains(content, "second entry") {
+		t.Error("second entry not found")
+	}
+}
+
+func TestAppendTodayCreatesWhenNoMatch(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runAppend(t, root, "brand new", "--slug", "nonexistent", "--today")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	base := filepath.Base(out)
+	today := time.Now().Format("20060102")
+	if !strings.HasPrefix(base, today) {
+		t.Errorf("expected filename to start with %s, got %s", today, base)
+	}
+
+	data, _ := os.ReadFile(out)
+	if !strings.Contains(string(data), "brand new") {
+		t.Error("appended content not found")
+	}
+}
+
+func TestAppendTodayWithTitle(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runAppend(t, root, "titled content", "--slug", "sessions", "--today",
+		"--title", "Claude Sessions")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, _ := os.ReadFile(out)
+	content := string(data)
+	if !strings.Contains(content, "title: Claude Sessions") {
+		t.Errorf("expected title in frontmatter, got:\n%s", content)
+	}
+	if !strings.Contains(content, "titled content") {
+		t.Error("appended content not found")
+	}
+}
+
+func TestAppendTodayWithPositionalArgErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runAppend(t, root, "text", "8823", "--today")
+	if err == nil {
+		t.Fatal("expected error when combining --today with positional arg, got nil")
+	}
+}
+
+func TestAppendTodayWithCreateErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runAppend(t, root, "text", "--slug", "meeting", "--today", "--create")
+	if err == nil {
+		t.Fatal("expected error when combining --today with --create, got nil")
+	}
+}
+
+func TestAppendTodayWithoutFiltersErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runAppend(t, root, "text", "--today")
+	if err == nil {
+		t.Fatal("expected error when using --today without filter flags, got nil")
+	}
+}
+
+func TestAppendTitleWithoutCreateOrTodayErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runAppend(t, root, "text", "--type", "todo", "--title", "Oops")
+	if err == nil {
+		t.Fatal("expected error when using --title without --create or --today, got nil")
+	}
+}
+
+func TestAppendDescriptionWithoutCreateOrTodayErrors(t *testing.T) {
+	root := copyTestdata(t)
+	_, err := runAppend(t, root, "text", "--type", "todo", "--description", "Oops")
+	if err == nil {
+		t.Fatal("expected error when using --description without --create or --today, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `--today` flag to `notes append` that finds the latest matching note and appends to it if it's from today, or creates a new note otherwise
- `--title` and `--description` are used only when creating a new note
- `--today` and `--create` are mutually exclusive

## References

- Closes #49