### PR TITLE
Extract shared filter helper, normalize flag types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.60] - 2026-04-05
+
+### Changed
+
+- Extract shared filter helper (`addFilterFlags`, `readFilterFlags`, `applyFilters`) to eliminate duplicated filter pipeline across `ls`, `resolve`, `read`, and `append` ([#92])
+- Normalize `--type` flag to `StringSlice` on `read` and `append` for consistency with `ls` and `resolve` ([#92])
+
 ## [0.1.59] - 2026-04-05
 
 ### Removed
@@ -268,6 +275,7 @@
 - Add `new` and `new-todo` commands ([#2])
 - Add `--no-frontmatter` flag to `read` command ([#3], [#4])
 
+[0.1.60]: https://github.com/dreikanter/notescli/releases/tag/v0.1.60
 [0.1.59]: https://github.com/dreikanter/notescli/releases/tag/v0.1.59
 [0.1.58]: https://github.com/dreikanter/notescli/releases/tag/v0.1.58
 [0.1.57]: https://github.com/dreikanter/notescli/releases/tag/v0.1.57
@@ -356,4 +364,5 @@
 [#85]: https://github.com/dreikanter/notescli/issues/85
 [#88]: https://github.com/dreikanter/notescli/issues/88
 [#90]: https://github.com/dreikanter/notescli/issues/90
+[#92]: https://github.com/dreikanter/notescli/issues/92
 [#93]: https://github.com/dreikanter/notescli/issues/93

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/dreikanter/notescli/note"
 	"github.com/spf13/cobra"
@@ -34,17 +33,12 @@ var appendCmd = &cobra.Command{
 			return nil
 		}
 
-		noteType, _ := cmd.Flags().GetString("type")
-		slug, _ := cmd.Flags().GetString("slug")
-		tags, _ := cmd.Flags().GetStringSlice("tag")
-		today, _ := cmd.Flags().GetBool("today")
-
-		hasFilters := noteType != "" || slug != "" || len(tags) > 0 || today
+		f := readFilterFlags(cmd)
 
 		var targetPath string
 
 		if len(args) == 1 {
-			if hasFilters {
+			if f.active() {
 				return fmt.Errorf("cannot combine positional argument with filter flags")
 			}
 
@@ -53,26 +47,15 @@ var appendCmd = &cobra.Command{
 				return resolveErr
 			}
 			targetPath = filepath.Join(root, n.RelPath)
-		} else if hasFilters {
+		} else if f.active() {
 			notes, scanErr := note.Scan(root)
 			if scanErr != nil {
 				return scanErr
 			}
 
-			if today {
-				notes = note.FilterByDate(notes, time.Now().Format("20060102"))
-			}
-			if noteType != "" {
-				notes = note.FilterByTypes(notes, []string{noteType})
-			}
-			if slug != "" {
-				notes = note.FilterBySlug(notes, slug)
-			}
-			if len(tags) > 0 {
-				notes, err = note.FilterByTags(notes, root, tags)
-				if err != nil {
-					return err
-				}
+			notes, err = applyFilters(notes, root, f)
+			if err != nil {
+				return err
 			}
 
 			if len(notes) == 0 {
@@ -106,10 +89,7 @@ var appendCmd = &cobra.Command{
 }
 
 func registerAppendFlags() {
-	appendCmd.Flags().String("type", "", "filter by note type")
-	appendCmd.Flags().String("slug", "", "filter by slug")
-	appendCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
-	appendCmd.Flags().Bool("today", false, "only match notes created today")
+	addFilterFlags(appendCmd)
 }
 
 func init() {

--- a/internal/cli/filter.go
+++ b/internal/cli/filter.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"time"
+
+	"github.com/dreikanter/notescli/note"
+	"github.com/spf13/cobra"
+)
+
+// filterOpts holds the common filter flag values.
+type filterOpts struct {
+	Today bool
+	Types []string
+	Slug  string
+	Tags  []string
+}
+
+// readFilterFlags reads the common filter flags from a cobra command.
+func readFilterFlags(cmd *cobra.Command) filterOpts {
+	today, _ := cmd.Flags().GetBool("today")
+	types, _ := cmd.Flags().GetStringSlice("type")
+	slug, _ := cmd.Flags().GetString("slug")
+	tags, _ := cmd.Flags().GetStringSlice("tag")
+	return filterOpts{Today: today, Types: types, Slug: slug, Tags: tags}
+}
+
+func (f filterOpts) active() bool {
+	return f.Today || len(f.Types) > 0 || f.Slug != "" || len(f.Tags) > 0
+}
+
+// applyFilters applies the common filter pipeline to a list of notes.
+func applyFilters(notes []note.Note, root string, f filterOpts) ([]note.Note, error) {
+	if f.Today {
+		notes = note.FilterByDate(notes, time.Now().Format("20060102"))
+	}
+	if len(f.Types) > 0 {
+		notes = note.FilterByTypes(notes, f.Types)
+	}
+	if f.Slug != "" {
+		notes = note.FilterBySlug(notes, f.Slug)
+	}
+	if len(f.Tags) > 0 {
+		var err error
+		notes, err = note.FilterByTags(notes, root, f.Tags)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return notes, nil
+}
+
+// addFilterFlags registers the common filter flags on a command.
+func addFilterFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("today", false, "only match notes created today")
+	cmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
+	cmd.Flags().String("slug", "", "filter by slug")
+	cmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
+}

--- a/internal/cli/filter.go
+++ b/internal/cli/filter.go
@@ -25,7 +25,11 @@ func readFilterFlags(cmd *cobra.Command) filterOpts {
 }
 
 func (f filterOpts) active() bool {
-	return f.Today || len(f.Types) > 0 || f.Slug != "" || len(f.Tags) > 0
+	return f.Today || f.hasAttributeFilters()
+}
+
+func (f filterOpts) hasAttributeFilters() bool {
+	return len(f.Types) > 0 || f.Slug != "" || len(f.Tags) > 0
 }
 
 // applyFilters applies the common filter pipeline to a list of notes.

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	"github.com/dreikanter/notescli/note"
 	"github.com/spf13/cobra"
@@ -15,11 +14,8 @@ var lsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		lsLimit, _ := cmd.Flags().GetInt("limit")
-		lsTypes, _ := cmd.Flags().GetStringSlice("type")
-		lsSlug, _ := cmd.Flags().GetString("slug")
-		lsTags, _ := cmd.Flags().GetStringSlice("tag")
 		lsName, _ := cmd.Flags().GetString("name")
-		lsToday, _ := cmd.Flags().GetBool("today")
+		f := readFilterFlags(cmd)
 
 		root := mustNotesPath()
 		notes, err := note.Scan(root)
@@ -27,27 +23,13 @@ var lsCmd = &cobra.Command{
 			return err
 		}
 
-		if lsToday {
-			notes = note.FilterByDate(notes, time.Now().Format("20060102"))
-		}
-
 		if lsName != "" {
 			notes = note.Filter(notes, lsName)
 		}
 
-		if len(lsTypes) > 0 {
-			notes = note.FilterByTypes(notes, lsTypes)
-		}
-
-		if lsSlug != "" {
-			notes = note.FilterBySlug(notes, lsSlug)
-		}
-
-		if len(lsTags) > 0 {
-			notes, err = note.FilterByTags(notes, root, lsTags)
-			if err != nil {
-				return err
-			}
+		notes, err = applyFilters(notes, root, f)
+		if err != nil {
+			return err
 		}
 
 		if lsLimit > 0 && len(notes) > lsLimit {
@@ -63,10 +45,7 @@ var lsCmd = &cobra.Command{
 
 func init() {
 	lsCmd.Flags().Int("limit", 0, "maximum number of notes to list (0 = no limit)")
-	lsCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
-	lsCmd.Flags().String("slug", "", "filter by slug")
-	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
 	lsCmd.Flags().String("name", "", "filter by filename fragment (case-insensitive substring)")
-	lsCmd.Flags().Bool("today", false, "filter notes created today")
+	addFilterFlags(lsCmd)
 	rootCmd.AddCommand(lsCmd)
 }

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -13,11 +13,8 @@ func runLs(t *testing.T, args ...string) (string, error) {
 	root := testdataPath(t)
 	lsCmd.ResetFlags()
 	lsCmd.Flags().Int("limit", 0, "maximum number of notes to list (0 = no limit)")
-	lsCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
-	lsCmd.Flags().String("slug", "", "filter by slug")
-	lsCmd.Flags().StringSlice("tag", nil, "filter by frontmatter tag (repeatable, AND logic)")
 	lsCmd.Flags().String("name", "", "filter by filename fragment (case-insensitive substring)")
-	lsCmd.Flags().Bool("today", false, "filter notes created today")
+	addFilterFlags(lsCmd)
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/dreikanter/notescli/note"
 	"github.com/spf13/cobra"
@@ -16,19 +15,13 @@ var readCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := mustNotesPath()
-
-		noteType, _ := cmd.Flags().GetString("type")
-		slug, _ := cmd.Flags().GetString("slug")
-		tags, _ := cmd.Flags().GetStringSlice("tag")
-		today, _ := cmd.Flags().GetBool("today")
+		f := readFilterFlags(cmd)
 		noFrontmatter, _ := cmd.Flags().GetBool("no-frontmatter")
-
-		hasFilters := noteType != "" || slug != "" || len(tags) > 0 || today
 
 		var relPath string
 
 		if len(args) == 1 {
-			if hasFilters {
+			if f.active() {
 				return fmt.Errorf("cannot combine positional argument with filter flags")
 			}
 			n, err := note.ResolveRef(root, args[0])
@@ -36,26 +29,15 @@ var readCmd = &cobra.Command{
 				return err
 			}
 			relPath = n.RelPath
-		} else if hasFilters {
+		} else if f.active() {
 			notes, err := note.Scan(root)
 			if err != nil {
 				return err
 			}
 
-			if today {
-				notes = note.FilterByDate(notes, time.Now().Format("20060102"))
-			}
-			if noteType != "" {
-				notes = note.FilterByTypes(notes, []string{noteType})
-			}
-			if slug != "" {
-				notes = note.FilterBySlug(notes, slug)
-			}
-			if len(tags) > 0 {
-				notes, err = note.FilterByTags(notes, root, tags)
-				if err != nil {
-					return err
-				}
+			notes, err = applyFilters(notes, root, f)
+			if err != nil {
+				return err
 			}
 
 			if len(notes) == 0 {
@@ -81,10 +63,7 @@ var readCmd = &cobra.Command{
 }
 
 func registerReadFlags() {
-	readCmd.Flags().String("type", "", "filter by note type")
-	readCmd.Flags().String("slug", "", "filter by slug")
-	readCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
-	readCmd.Flags().Bool("today", false, "only match notes created today")
+	addFilterFlags(readCmd)
 	readCmd.Flags().BoolP("no-frontmatter", "F", false, "exclude YAML frontmatter from output")
 }
 

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -26,21 +26,17 @@ positional argument.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := mustNotesPath()
+		f := readFilterFlags(cmd)
 
-		today, _ := cmd.Flags().GetBool("today")
-		types, _ := cmd.Flags().GetStringSlice("type")
-		slug, _ := cmd.Flags().GetString("slug")
-		tags, _ := cmd.Flags().GetStringSlice("tag")
-
-		hasFilters := len(types) > 0 || slug != "" || len(tags) > 0
+		hasNonTodayFilters := len(f.Types) > 0 || f.Slug != "" || len(f.Tags) > 0
 
 		if len(args) == 1 {
-			if hasFilters {
+			if hasNonTodayFilters {
 				return fmt.Errorf("cannot combine positional argument with filter flags")
 			}
 
 			var date string
-			if today {
+			if f.Today {
 				date = time.Now().Format("20060102")
 			}
 
@@ -53,7 +49,7 @@ positional argument.`,
 			return nil
 		}
 
-		if !hasFilters && !today {
+		if !f.active() {
 			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag, --today)")
 		}
 
@@ -62,20 +58,9 @@ positional argument.`,
 			return err
 		}
 
-		if today {
-			notes = note.FilterByDate(notes, time.Now().Format("20060102"))
-		}
-		if len(types) > 0 {
-			notes = note.FilterByTypes(notes, types)
-		}
-		if slug != "" {
-			notes = note.FilterBySlug(notes, slug)
-		}
-		if len(tags) > 0 {
-			notes, err = note.FilterByTags(notes, root, tags)
-			if err != nil {
-				return err
-			}
+		notes, err = applyFilters(notes, root, f)
+		if err != nil {
+			return err
 		}
 
 		if len(notes) == 0 {
@@ -88,10 +73,7 @@ positional argument.`,
 }
 
 func registerResolveFlags() {
-	resolveCmd.Flags().Bool("today", false, "only match notes created today")
-	resolveCmd.Flags().StringSlice("type", nil, "filter by note type (repeatable)")
-	resolveCmd.Flags().String("slug", "", "filter by slug")
-	resolveCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
+	addFilterFlags(resolveCmd)
 }
 
 func init() {

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -28,10 +28,8 @@ positional argument.`,
 		root := mustNotesPath()
 		f := readFilterFlags(cmd)
 
-		hasNonTodayFilters := len(f.Types) > 0 || f.Slug != "" || len(f.Tags) > 0
-
 		if len(args) == 1 {
-			if hasNonTodayFilters {
+			if f.hasAttributeFilters() {
 				return fmt.Errorf("cannot combine positional argument with filter flags")
 			}
 


### PR DESCRIPTION
## Summary

- Extract `addFilterFlags`, `readFilterFlags`, `applyFilters`, and `filterOpts` into `filter.go` to eliminate the duplicated filter pipeline across `ls`, `resolve`, `read`, and `append`
- Extract `hasAttributeFilters()` method on `filterOpts` to centralize the non-today filter check used by `resolve`
- Normalize `--type` flag from `String` to `StringSlice` on `read` and `append`, matching `ls` and `resolve` — `read --type todo --type backlog` now works
- Net -16 lines; filter logic defined once instead of 4 times

## References

- Closes #92
- Relates to #85