### PR TITLE
Make resolve with no args return the most recent note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.62] - 2026-04-05
+
+### Changed
+
+- `resolve` with no arguments returns the most recent note ([#97])
+
 ## [0.1.60] - 2026-04-05
 
 ### Changed
@@ -366,3 +372,4 @@
 [#90]: https://github.com/dreikanter/notescli/issues/90
 [#92]: https://github.com/dreikanter/notescli/issues/92
 [#93]: https://github.com/dreikanter/notescli/issues/93
+[#97]: https://github.com/dreikanter/notescli/pull/97

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -14,6 +14,8 @@ var resolveCmd = &cobra.Command{
 	Short: "Resolve a note reference and print its absolute path",
 	Long: `Resolve a note reference and print its absolute path.
 
+With no arguments or flags, returns the most recent note.
+
 With a positional argument, resolution follows this priority:
   1. Exact numeric ID (e.g. "8823")
   2. Exact note type (todo, backlog, weekly) — most recent match
@@ -45,10 +47,6 @@ positional argument.`,
 
 			fmt.Fprintln(cmd.OutOrStdout(), filepath.Join(root, n.RelPath))
 			return nil
-		}
-
-		if !f.active() {
-			return fmt.Errorf("specify a note by positional argument or filter flags (--type, --slug, --tag, --today)")
 		}
 
 		notes, err := note.Scan(root)

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -170,11 +170,16 @@ func TestResolveTodayFilterMatchesToday(t *testing.T) {
 	}
 }
 
-func TestResolveNoArgsNoFiltersErrors(t *testing.T) {
+func TestResolveNoArgsReturnsMostRecent(t *testing.T) {
 	root := testdataPath(t)
-	_, err := runResolve(t, root)
-	if err == nil {
-		t.Fatal("expected error when no args and no filters, got nil")
+	out, err := runResolve(t, root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, "2026/01/20260106_8823_999.md")
+	if out != want {
+		t.Errorf("got %q, want %q", out, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `resolve` with no arguments returns the most recent note instead of erroring, enabling `notes edit $(notes resolve)` as a shortcut to open the latest note

## References

- relates to #60
- relates to #85