### PR TITLE
Detach GUI editors in edit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.64] - 2026-04-05
+
+### Changed
+
+- Detach GUI editors in `edit` command so control returns to terminal immediately; terminal editors (vim, nano, etc.) still run in foreground ([#99])
+
 ## [0.1.63] - 2026-04-05
 
 ### Changed
@@ -381,3 +387,4 @@
 [#93]: https://github.com/dreikanter/notescli/issues/93
 [#97]: https://github.com/dreikanter/notescli/pull/97
 [#98]: https://github.com/dreikanter/notescli/pull/98
+[#99]: https://github.com/dreikanter/notescli/pull/99

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -69,7 +69,9 @@ The editor value may include arguments, e.g. EDITOR="subl --wait".`,
 
 		bin, extraArgs := parseEditor(raw)
 		path := filepath.Join(root, n.RelPath)
-		cmdArgs := append(extraArgs, path)
+		cmdArgs := make([]string, 0, len(extraArgs)+1)
+		cmdArgs = append(cmdArgs, extraArgs...)
+		cmdArgs = append(cmdArgs, path)
 		ec := exec.Command(bin, cmdArgs...)
 
 		if isTerminalEditor(bin) {

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -46,7 +46,12 @@ func isTerminalEditor(bin string) bool {
 var editCmd = &cobra.Command{
 	Use:   "edit <id|type|query>",
 	Short: "Open a note in your editor",
-	Args:  cobra.ExactArgs(1),
+	Long: `Open a note in your editor. The editor is read from $VISUAL, falling back to $EDITOR.
+
+Terminal editors (vi, vim, nvim, nano, emacs, micro, etc.) run in the foreground with the terminal attached. All other editors are launched as detached processes so control returns to the terminal immediately.
+
+The editor value may include arguments, e.g. EDITOR="subl --wait".`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		root := mustNotesPath()
 		n, err := note.ResolveRef(root, args[0])

--- a/internal/cli/edit.go
+++ b/internal/cli/edit.go
@@ -5,10 +5,43 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/dreikanter/notescli/note"
 	"github.com/spf13/cobra"
 )
+
+// terminalEditors is the set of editors that need a terminal (stdin/stdout).
+// Everything else is assumed to be a GUI app and launched detached.
+var terminalEditors = map[string]bool{
+	"ed":     true,
+	"emacs":  true,
+	"jed":    true,
+	"joe":    true,
+	"mcedit": true,
+	"micro":  true,
+	"nano":   true,
+	"ne":     true,
+	"nvim":   true,
+	"pico":   true,
+	"vi":     true,
+	"vim":    true,
+}
+
+// parseEditor splits an editor string (e.g. "subl --wait") into the binary
+// name and any extra arguments.
+func parseEditor(raw string) (string, []string) {
+	parts := strings.Fields(raw)
+	if len(parts) == 0 {
+		return "", nil
+	}
+	return parts[0], parts[1:]
+}
+
+// isTerminalEditor returns true if the given binary name is a known terminal editor.
+func isTerminalEditor(bin string) bool {
+	return terminalEditors[filepath.Base(bin)]
+}
 
 var editCmd = &cobra.Command{
 	Use:   "edit <id|type|query>",
@@ -21,21 +54,27 @@ var editCmd = &cobra.Command{
 			return err
 		}
 
-		editor := os.Getenv("VISUAL")
-		if editor == "" {
-			editor = os.Getenv("EDITOR")
+		raw := os.Getenv("VISUAL")
+		if raw == "" {
+			raw = os.Getenv("EDITOR")
 		}
-		if editor == "" {
+		if raw == "" {
 			return fmt.Errorf("no editor configured: set $EDITOR or $VISUAL")
 		}
 
+		bin, extraArgs := parseEditor(raw)
 		path := filepath.Join(root, n.RelPath)
-		ec := exec.Command(editor, path)
-		ec.Stdin = os.Stdin
-		ec.Stdout = os.Stdout
-		ec.Stderr = os.Stderr
+		cmdArgs := append(extraArgs, path)
+		ec := exec.Command(bin, cmdArgs...)
 
-		return ec.Run()
+		if isTerminalEditor(bin) {
+			ec.Stdin = os.Stdin
+			ec.Stdout = os.Stdout
+			ec.Stderr = os.Stderr
+			return ec.Run()
+		}
+
+		return ec.Start()
 	},
 }
 

--- a/internal/cli/edit_test.go
+++ b/internal/cli/edit_test.go
@@ -8,6 +8,94 @@ import (
 	"testing"
 )
 
+func TestParseEditor(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantBin  string
+		wantArgs []string
+	}{
+		{"vim", "vim", nil},
+		{"subl --wait", "subl", []string{"--wait"}},
+		{"/usr/bin/code -w --new-window", "/usr/bin/code", []string{"-w", "--new-window"}},
+		{"", "", nil},
+	}
+	for _, tt := range tests {
+		bin, args := parseEditor(tt.input)
+		if bin != tt.wantBin {
+			t.Errorf("parseEditor(%q) bin = %q, want %q", tt.input, bin, tt.wantBin)
+		}
+		if len(args) != len(tt.wantArgs) {
+			t.Errorf("parseEditor(%q) args = %v, want %v", tt.input, args, tt.wantArgs)
+			continue
+		}
+		for i := range args {
+			if args[i] != tt.wantArgs[i] {
+				t.Errorf("parseEditor(%q) args[%d] = %q, want %q", tt.input, i, args[i], tt.wantArgs[i])
+			}
+		}
+	}
+}
+
+func TestIsTerminalEditor(t *testing.T) {
+	for _, name := range []string{"vim", "nvim", "nano", "emacs", "vi", "micro"} {
+		if !isTerminalEditor(name) {
+			t.Errorf("expected %q to be a terminal editor", name)
+		}
+	}
+	if !isTerminalEditor("/usr/bin/vim") {
+		t.Error("expected /usr/bin/vim to be a terminal editor")
+	}
+	for _, name := range []string{"code", "subl", "zed", "gedit"} {
+		if isTerminalEditor(name) {
+			t.Errorf("expected %q to NOT be a terminal editor", name)
+		}
+	}
+}
+
+// writeFakeEditor creates a shell script named after a known terminal editor
+// so the edit command runs it in foreground mode.
+func writeFakeEditor(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := filepath.Join(dir, "vi")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script
+}
+
+func TestEditPassesArgsToEditor(t *testing.T) {
+	root := testdataPath(t)
+
+	marker := filepath.Join(t.TempDir(), "edited")
+	script := writeFakeEditor(t, `for arg in "$@"; do echo "$arg"; done > `+marker)
+
+	t.Setenv("VISUAL", "")
+	t.Setenv("EDITOR", script+" --flag")
+
+	_, err := runEdit(t, root, "8823")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("marker file not created: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(got)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (flag + path), got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "--flag" {
+		t.Errorf("first arg = %q, want %q", lines[0], "--flag")
+	}
+	want := filepath.Join(root, "2026/01/20260106_8823_999.md")
+	if lines[1] != want {
+		t.Errorf("second arg = %q, want %q", lines[1], want)
+	}
+}
+
 func runEdit(t *testing.T, root string, args ...string) (string, error) {
 	t.Helper()
 
@@ -24,18 +112,13 @@ func runEdit(t *testing.T, root string, args ...string) (string, error) {
 func TestEditOpensEditor(t *testing.T) {
 	root := testdataPath(t)
 
-	// Use a script that writes the received path to a temp file
 	marker := filepath.Join(t.TempDir(), "edited")
-	script := filepath.Join(t.TempDir(), "fake-editor.sh")
-	err := os.WriteFile(script, []byte("#!/bin/sh\necho \"$1\" > "+marker+"\n"), 0o755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	script := writeFakeEditor(t, `echo "$1" > `+marker)
 
 	t.Setenv("VISUAL", "")
 	t.Setenv("EDITOR", script)
 
-	_, err = runEdit(t, root, "8823")
+	_, err := runEdit(t, root, "8823")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,22 +138,14 @@ func TestEditPrefersVisual(t *testing.T) {
 	root := testdataPath(t)
 
 	marker := filepath.Join(t.TempDir(), "edited")
-	script := filepath.Join(t.TempDir(), "fake-editor.sh")
-	err := os.WriteFile(script, []byte("#!/bin/sh\necho \"$1\" > "+marker+"\n"), 0o755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	script := writeFakeEditor(t, `echo "$1" > `+marker)
 
-	badScript := filepath.Join(t.TempDir(), "bad-editor.sh")
-	err = os.WriteFile(badScript, []byte("#!/bin/sh\nexit 1\n"), 0o755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	badScript := writeFakeEditor(t, "exit 1")
 
 	t.Setenv("VISUAL", script)
 	t.Setenv("EDITOR", badScript)
 
-	_, err = runEdit(t, root, "8823")
+	_, err := runEdit(t, root, "8823")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -116,16 +191,12 @@ func TestEditBySlug(t *testing.T) {
 	root := testdataPath(t)
 
 	marker := filepath.Join(t.TempDir(), "edited")
-	script := filepath.Join(t.TempDir(), "fake-editor.sh")
-	err := os.WriteFile(script, []byte("#!/bin/sh\necho \"$1\" > "+marker+"\n"), 0o755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	script := writeFakeEditor(t, `echo "$1" > `+marker)
 
 	t.Setenv("VISUAL", "")
 	t.Setenv("EDITOR", script)
 
-	_, err = runEdit(t, root, "meeting")
+	_, err := runEdit(t, root, "meeting")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -145,16 +216,12 @@ func TestEditByType(t *testing.T) {
 	root := testdataPath(t)
 
 	marker := filepath.Join(t.TempDir(), "edited")
-	script := filepath.Join(t.TempDir(), "fake-editor.sh")
-	err := os.WriteFile(script, []byte("#!/bin/sh\necho \"$1\" > "+marker+"\n"), 0o755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	script := writeFakeEditor(t, `echo "$1" > `+marker)
 
 	t.Setenv("VISUAL", "")
 	t.Setenv("EDITOR", script)
 
-	_, err = runEdit(t, root, "todo")
+	_, err := runEdit(t, root, "todo")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- GUI editors (code, subl, zed, etc.) are now launched detached so control returns to the terminal immediately
- Terminal editors (vim, nano, emacs, etc.) still run in the foreground with stdin/stdout attached
- Editor env var values with arguments (e.g. `EDITOR="subl --wait"`) are now parsed correctly