### PR TITLE
docs: forbid session URLs in PR bodies and commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.22] - 2026-04-23
+
+### Changed
+
+- CLAUDE.md: added rule prohibiting session URLs and tooling attribution in PR bodies, commit messages, and repository artifacts ([#214])
+
+[#214]: https://github.com/dreikanter/notes-cli/pull/214
+
 ## [0.2.21] - 2026-04-23
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,5 @@ a follow-up commit on the same branch:
 ## Pull Requests
 
 Use `.github/pull_request_template.md` for all PR bodies. When running `gh pr create`, pass its content via `--body`.
+
+Never include session URLs (e.g. `https://claude.ai/code/session_...`) or any other tooling attribution in PR bodies, commit messages, or anywhere else in the repository.


### PR DESCRIPTION
## Summary

- Add CLAUDE.md rule prohibiting session URLs and tooling attribution in PR bodies, commit messages, and repository artifacts

## References

- relates to #162

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXbEFRuRxDf3Qybp7NUdnW)_