### PR TITLE
Refactor stdin handling and reorganize test files

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"io"
-	"os"
 	"time"
 
 	"github.com/dreikanter/notes-cli/note"
@@ -72,22 +70,6 @@ var newCmd = &cobra.Command{
 	},
 }
 
-// stdinIsTerminal reports whether in looks like an interactive terminal. Only
-// *os.File readers are heuristically inspected; any other reader (a pipe,
-// buffer, or other io.Reader injected via cmd.SetIn) is treated as non-terminal
-// so tests and piped invocations read the provided bytes.
-func stdinIsTerminal(in io.Reader) bool {
-	f, ok := in.(*os.File)
-	if !ok {
-		return false
-	}
-	fi, err := f.Stat()
-	if err != nil {
-		return true
-	}
-	return fi.Mode()&os.ModeCharDevice != 0
-}
-
 // findUpsertEntry looks for today's note matching noteType and slug.
 // Returns (entry, true, nil) on hit, (zero, false, nil) on clean miss, and
 // a non-nil error only for I/O failures.
@@ -107,20 +89,6 @@ func findUpsertEntry(store note.Store, noteType, slug string) (note.Entry, bool,
 		return note.Entry{}, false, err
 	}
 	return entry, true, nil
-}
-
-// readStdinBody reads stdin when it is not a terminal and returns its content.
-// Returns ("", nil) when stdin is a terminal (no piped input).
-func readStdinBody(cmd *cobra.Command) (string, error) {
-	in := cmd.InOrStdin()
-	if stdinIsTerminal(in) {
-		return "", nil
-	}
-	data, err := io.ReadAll(in)
-	if err != nil {
-		return "", fmt.Errorf("cannot read stdin: %w", err)
-	}
-	return string(data), nil
 }
 
 func registerNewFlags() {

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -123,10 +123,3 @@ func TestResolveMultipleFlagsError(t *testing.T) {
 		t.Fatal("expected error when combining --id and --slug")
 	}
 }
-
-func TestResolveEditCommandRemoved(t *testing.T) {
-	cmd, _, err := rootCmd.Find([]string{"edit"})
-	if err == nil && cmd != nil && cmd.Use != "" && strings.HasPrefix(cmd.Use, "edit") {
-		t.Errorf("edit command should be removed, found: %+v", cmd)
-	}
-}

--- a/internal/cli/stdin.go
+++ b/internal/cli/stdin.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// stdinIsTerminal reports whether in looks like an interactive terminal. Only
+// *os.File readers are heuristically inspected; any other reader (a pipe,
+// buffer, or other io.Reader injected via cmd.SetIn) is treated as non-terminal
+// so tests and piped invocations read the provided bytes.
+func stdinIsTerminal(in io.Reader) bool {
+	f, ok := in.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return true
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// readStdinBody reads stdin when it is not a terminal and returns its content.
+// Returns ("", nil) when stdin is a terminal (no piped input).
+func readStdinBody(cmd *cobra.Command) (string, error) {
+	in := cmd.InOrStdin()
+	if stdinIsTerminal(in) {
+		return "", nil
+	}
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return "", fmt.Errorf("cannot read stdin: %w", err)
+	}
+	return string(data), nil
+}

--- a/note/mem_store.go
+++ b/note/mem_store.go
@@ -65,7 +65,7 @@ func (s *MemStore) Find(opts ...QueryOpt) (Entry, error) {
 
 	matches := s.matchLocked(q)
 	if len(matches) == 0 {
-		return Entry{}, fmt.Errorf("%w", ErrNotFound)
+		return Entry{}, ErrNotFound
 	}
 	s.sortEntriesByRecency(matches)
 	return matches[0], nil

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -205,3 +205,38 @@ func TestHasSpecialBehavior(t *testing.T) {
 		t.Error("expected empty string to have no special behavior")
 	}
 }
+
+func TestFilename(t *testing.T) {
+	tests := []struct {
+		date     string
+		id       int
+		slug     string
+		noteType string
+		want     string
+	}{
+		{"20260312", 9219, "", "", "20260312_9219.md"},
+		{"20260312", 9219, "my-note", "", "20260312_9219_my-note.md"},
+		{"20260312", 9219, "", "todo", "20260312_9219.todo.md"},
+		{"20260312", 9219, "standup", "todo", "20260312_9219_standup.todo.md"},
+		{"20260312", 9219, "", "backlog", "20260312_9219.backlog.md"},
+		// Unsafe types are omitted from the filename (frontmatter remains canonical).
+		{"20260312", 9219, "", "foo.bar", "20260312_9219.md"},
+		{"20260312", 9219, "", "a/b", "20260312_9219.md"},
+		{"20260312", 9219, "", `a\b`, "20260312_9219.md"},
+	}
+
+	for _, tt := range tests {
+		got := Filename(tt.date, tt.id, tt.slug, tt.noteType)
+		if got != tt.want {
+			t.Errorf("Filename(%q, %d, %q, %q) = %q, want %q", tt.date, tt.id, tt.slug, tt.noteType, got, tt.want)
+		}
+	}
+}
+
+func TestDirPath(t *testing.T) {
+	got := DirPath("/archive", "20260312")
+	want := "/archive/2026/03"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/note/os_store.go
+++ b/note/os_store.go
@@ -16,9 +16,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// dateLayout is the filename date format — 8 digits, YYYYMMDD.
-const dateLayout = "20060102"
-
 // OSStore is the filesystem-backed Store. It wraps the existing
 // root/YYYY/MM/YYYYMMDD_id_slug.md layout and reuses the package's existing
 // filename, frontmatter, and atomic-write helpers.
@@ -146,12 +143,12 @@ func refMatchesFilename(r fileRef, q query) bool {
 		return false
 	}
 	if q.dateSet {
-		if r.date != q.date.Format(dateLayout) {
+		if r.date != q.date.Format(DateFormat) {
 			return false
 		}
 	}
 	if q.beforeSet {
-		if !(r.date < q.beforeDate.Format(dateLayout)) {
+		if !(r.date < q.beforeDate.Format(DateFormat)) {
 			return false
 		}
 	}
@@ -401,7 +398,7 @@ func (s *OSStore) AbsPath(entry Entry) string {
 
 // pathFor returns the rel/abs path the filename layout produces for entry.
 func (s *OSStore) pathFor(entry Entry) (rel, abs string) {
-	date := entry.Meta.CreatedAt.Format(dateLayout)
+	date := entry.Meta.CreatedAt.Format(DateFormat)
 	name := Filename(date, entry.ID, entry.Meta.Slug, entry.Meta.Type)
 	dir := DirPath(s.root, date)
 	abs = filepath.Join(dir, name)
@@ -416,7 +413,7 @@ func (s *OSStore) pathFor(entry Entry) (rel, abs string) {
 func frontmatterToMeta(fm frontmatter, r fileRef, modTime time.Time, body []byte) Meta {
 	created := fm.Date
 	if created.IsZero() {
-		if t, err := time.Parse(dateLayout, r.date); err == nil {
+		if t, err := time.Parse(DateFormat, r.date); err == nil {
 			created = t
 		}
 	}

--- a/note/os_store.go
+++ b/note/os_store.go
@@ -177,7 +177,7 @@ func (s *OSStore) Find(opts ...QueryOpt) (Entry, error) {
 		return Entry{}, err
 	}
 	if len(entries) == 0 {
-		return Entry{}, fmt.Errorf("%w", ErrNotFound)
+		return Entry{}, ErrNotFound
 	}
 	return entries[0], nil
 }

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -278,38 +278,3 @@ func TestFormatTodoContentEmpty(t *testing.T) {
 		t.Errorf("got:\n%q\nwant empty string", content)
 	}
 }
-
-func TestFilename(t *testing.T) {
-	tests := []struct {
-		date     string
-		id       int
-		slug     string
-		noteType string
-		want     string
-	}{
-		{"20260312", 9219, "", "", "20260312_9219.md"},
-		{"20260312", 9219, "my-note", "", "20260312_9219_my-note.md"},
-		{"20260312", 9219, "", "todo", "20260312_9219.todo.md"},
-		{"20260312", 9219, "standup", "todo", "20260312_9219_standup.todo.md"},
-		{"20260312", 9219, "", "backlog", "20260312_9219.backlog.md"},
-		// Unsafe types are omitted from the filename (frontmatter remains canonical).
-		{"20260312", 9219, "", "foo.bar", "20260312_9219.md"},
-		{"20260312", 9219, "", "a/b", "20260312_9219.md"},
-		{"20260312", 9219, "", `a\b`, "20260312_9219.md"},
-	}
-
-	for _, tt := range tests {
-		got := Filename(tt.date, tt.id, tt.slug, tt.noteType)
-		if got != tt.want {
-			t.Errorf("Filename(%q, %d, %q, %q) = %q, want %q", tt.date, tt.id, tt.slug, tt.noteType, got, tt.want)
-		}
-	}
-}
-
-func TestDirPath(t *testing.T) {
-	got := DirPath("/archive", "20260312")
-	want := "/archive/2026/03"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-}


### PR DESCRIPTION
## Summary

- Extract stdin terminal detection and reading logic into a new `internal/cli/stdin.go` module for better code organization and reusability
- Move `TestFilename` and `TestDirPath` tests from `note/todo_test.go` to `note/note_test.go` to place them with related note package functionality
- Promote `dateLayout` constant to public `DateFormat` in the note package for use across modules
- Simplify error wrapping in `Find` methods by removing unnecessary `fmt.Errorf` wrapper around `ErrNotFound`
- Remove obsolete `TestResolveEditCommandRemoved` test that checked for a removed edit command

## References

- #215
