### PR TITLE
note: split store.go and storage.go by responsibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.17] - 2026-04-24
+
+### Changed
+
+- Split `note/storage.go` and `note/store.go` by responsibility: `store.go` now holds only the `Store` interface + `ErrNotFound`; query filters move to `note/query.go`; `ValidateSlug` + `slugRe` move to `note/slug.go`; `hasAllTags`, `computeMergedTags`, and `normalizeHashtags` merge into `note/tags.go` next to `ExtractHashtags` ([#247]).
+
+[#247]: https://github.com/dreikanter/notes-cli/pull/247
+
 ## [0.3.13] - 2026-04-24
 
 ### Changed

--- a/note/query.go
+++ b/note/query.go
@@ -1,59 +1,6 @@
 package note
 
-import (
-	"errors"
-	"time"
-)
-
-// ErrNotFound is the package-wide "entry not found" sentinel. It is returned
-// (wrapped) by Store.Get, Store.Find, and Store.Delete when no entry matches.
-// Callers match with errors.Is:
-//
-//	if errors.Is(err, note.ErrNotFound) { … }
-var ErrNotFound = errors.New("entry not found")
-
-// Store is the backend abstraction the note package exposes. Implementations
-// encapsulate the storage substrate (filesystem, in-memory, future cloud/DB)
-// so CLI commands can target a single interface.
-//
-// Error contract for lookups:
-//   - Get, Find, and Delete return a wrapped ErrNotFound when no entry
-//     matches. Callers check with errors.Is(err, note.ErrNotFound).
-//   - All returns an empty slice with a nil error when no entry matches;
-//     zero results are not considered an error.
-type Store interface {
-	// IDs returns the IDs of every entry newest-first by Meta.CreatedAt.
-	// Backends that can answer from a directory scan must not read file
-	// contents. Returns an empty slice (nil error) when the store is empty.
-	IDs() ([]int, error)
-
-	// All returns every entry matching opts, newest-first by Meta.CreatedAt.
-	// Returned entries are fully populated, including Meta.Tags merged from
-	// frontmatter tags and body hashtags. Zero matches returns an empty
-	// slice with a nil error.
-	All(opts ...QueryOpt) ([]Entry, error)
-
-	// Find returns the newest entry matching opts. Returns ErrNotFound when
-	// no entry matches. Backends may terminate the scan after the first
-	// match.
-	Find(opts ...QueryOpt) (Entry, error)
-
-	// Get returns the entry with the given ID, or ErrNotFound if no entry
-	// has that ID.
-	Get(id int) (Entry, error)
-
-	// Put writes entry. When entry.ID is zero the store assigns a fresh ID
-	// and defaults Meta.CreatedAt to time.Now if zero; otherwise Put performs
-	// a full replace of the existing entry and requires Meta.CreatedAt to be
-	// non-zero (returning an error otherwise). Meta.UpdatedAt is always set
-	// to time.Now on write. Returns the stored entry with all store-assigned
-	// fields populated.
-	Put(entry Entry) (Entry, error)
-
-	// Delete removes the entry with the given ID. Returns ErrNotFound when
-	// no entry has that ID.
-	Delete(id int) error
-}
+import "time"
 
 // query captures the filter state built up from QueryOpts. It is unexported
 // so that only Store implementations inside the note package can inspect it;

--- a/note/slug.go
+++ b/note/slug.go
@@ -1,0 +1,26 @@
+package note
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var slugRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// ValidateSlug returns an error if the slug cannot safely appear in a note
+// filename. Empty slugs are accepted (they just omit the slug segment).
+// All-digit slugs are rejected because they conflict with numeric ID lookup.
+// Anything outside [A-Za-z0-9_-] is rejected to keep filenames portable and to
+// avoid confusing the filename cache suffix.
+func ValidateSlug(slug string) error {
+	if slug == "" {
+		return nil
+	}
+	if IsDigits(slug) {
+		return fmt.Errorf("slug %q is all digits, which conflicts with note ID resolution", slug)
+	}
+	if !slugRe.MatchString(slug) {
+		return fmt.Errorf("slug %q contains invalid characters; only [A-Za-z0-9_-] are allowed", slug)
+	}
+	return nil
+}

--- a/note/store.go
+++ b/note/store.go
@@ -1,94 +1,53 @@
 package note
 
-import (
-	"fmt"
-	"regexp"
-	"sort"
-	"strings"
-)
+import "errors"
 
-var slugRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+// ErrNotFound is the package-wide "entry not found" sentinel. It is returned
+// (wrapped) by Store.Get, Store.Find, and Store.Delete when no entry matches.
+// Callers match with errors.Is:
+//
+//	if errors.Is(err, note.ErrNotFound) { … }
+var ErrNotFound = errors.New("entry not found")
 
-// ValidateSlug returns an error if the slug cannot safely appear in a note
-// filename. Empty slugs are accepted (they just omit the slug segment).
-// All-digit slugs are rejected because they conflict with numeric ID lookup.
-// Anything outside [A-Za-z0-9_-] is rejected to keep filenames portable and to
-// avoid confusing the filename cache suffix.
-func ValidateSlug(slug string) error {
-	if slug == "" {
-		return nil
-	}
-	if IsDigits(slug) {
-		return fmt.Errorf("slug %q is all digits, which conflicts with note ID resolution", slug)
-	}
-	if !slugRe.MatchString(slug) {
-		return fmt.Errorf("slug %q contains invalid characters; only [A-Za-z0-9_-] are allowed", slug)
-	}
-	return nil
-}
+// Store is the backend abstraction the note package exposes. Implementations
+// encapsulate the storage substrate (filesystem, in-memory, future cloud/DB)
+// so CLI commands can target a single interface.
+//
+// Error contract for lookups:
+//   - Get, Find, and Delete return a wrapped ErrNotFound when no entry
+//     matches. Callers check with errors.Is(err, note.ErrNotFound).
+//   - All returns an empty slice with a nil error when no entry matches;
+//     zero results are not considered an error.
+type Store interface {
+	// IDs returns the IDs of every entry newest-first by Meta.CreatedAt.
+	// Backends that can answer from a directory scan must not read file
+	// contents. Returns an empty slice (nil error) when the store is empty.
+	IDs() ([]int, error)
 
-// hasAllTags reports whether every entry in required appears in noteTags,
-// case-insensitively. Used by both MemStore and OSStore for WithTag filtering.
-func hasAllTags(noteTags []string, required []string) bool {
-	set := make(map[string]struct{}, len(noteTags))
-	for _, t := range noteTags {
-		set[strings.ToLower(t)] = struct{}{}
-	}
-	for _, r := range required {
-		if _, ok := set[strings.ToLower(r)]; !ok {
-			return false
-		}
-	}
-	return true
-}
+	// All returns every entry matching opts, newest-first by Meta.CreatedAt.
+	// Returned entries are fully populated, including Meta.Tags merged from
+	// frontmatter tags and body hashtags. Zero matches returns an empty
+	// slice with a nil error.
+	All(opts ...QueryOpt) ([]Entry, error)
 
-// computeMergedTags builds the sorted, lowercased, deduplicated union of
-// frontmatter tags and body hashtags. bodyHashtags is assumed already
-// lowercased (as produced by normalizeHashtags). Returns nil when the
-// union is empty.
-func computeMergedTags(fmTags, bodyHashtags []string) []string {
-	set := make(map[string]struct{}, len(fmTags)+len(bodyHashtags))
-	for _, t := range fmTags {
-		if t == "" {
-			continue
-		}
-		set[strings.ToLower(t)] = struct{}{}
-	}
-	for _, t := range bodyHashtags {
-		set[t] = struct{}{}
-	}
-	if len(set) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(set))
-	for t := range set {
-		out = append(out, t)
-	}
-	sort.Strings(out)
-	return out
-}
+	// Find returns the newest entry matching opts. Returns ErrNotFound when
+	// no entry matches. Backends may terminate the scan after the first
+	// match.
+	Find(opts ...QueryOpt) (Entry, error)
 
-// normalizeHashtags lowercases and deduplicates a hashtag list from
-// ExtractHashtags into the canonical form merged into Meta.Tags by
-// OSStore.
-func normalizeHashtags(raw []string) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-	set := make(map[string]struct{}, len(raw))
-	for _, t := range raw {
-		if t == "" {
-			continue
-		}
-		set[strings.ToLower(t)] = struct{}{}
-	}
-	if len(set) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(set))
-	for t := range set {
-		out = append(out, t)
-	}
-	sort.Strings(out)
-	return out
+	// Get returns the entry with the given ID, or ErrNotFound if no entry
+	// has that ID.
+	Get(id int) (Entry, error)
+
+	// Put writes entry. When entry.ID is zero the store assigns a fresh ID
+	// and defaults Meta.CreatedAt to time.Now if zero; otherwise Put performs
+	// a full replace of the existing entry and requires Meta.CreatedAt to be
+	// non-zero (returning an error otherwise). Meta.UpdatedAt is always set
+	// to time.Now on write. Returns the stored entry with all store-assigned
+	// fields populated.
+	Put(entry Entry) (Entry, error)
+
+	// Delete removes the entry with the given ID. Returns ErrNotFound when
+	// no entry has that ID.
+	Delete(id int) error
 }

--- a/note/tags.go
+++ b/note/tags.go
@@ -2,6 +2,8 @@ package note
 
 import (
 	"bytes"
+	"sort"
+	"strings"
 )
 
 // ExtractHashtags scans body text and returns hashtag tokens (without the
@@ -109,4 +111,70 @@ func isHashtagLeadingByte(c byte) bool {
 		return false
 	}
 	return true
+}
+
+// hasAllTags reports whether every entry in required appears in noteTags,
+// case-insensitively. Used by both MemStore and OSStore for WithTag filtering.
+func hasAllTags(noteTags []string, required []string) bool {
+	set := make(map[string]struct{}, len(noteTags))
+	for _, t := range noteTags {
+		set[strings.ToLower(t)] = struct{}{}
+	}
+	for _, r := range required {
+		if _, ok := set[strings.ToLower(r)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// computeMergedTags builds the sorted, lowercased, deduplicated union of
+// frontmatter tags and body hashtags. bodyHashtags is assumed already
+// lowercased (as produced by normalizeHashtags). Returns nil when the
+// union is empty.
+func computeMergedTags(fmTags, bodyHashtags []string) []string {
+	set := make(map[string]struct{}, len(fmTags)+len(bodyHashtags))
+	for _, t := range fmTags {
+		if t == "" {
+			continue
+		}
+		set[strings.ToLower(t)] = struct{}{}
+	}
+	for _, t := range bodyHashtags {
+		set[t] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for t := range set {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// normalizeHashtags lowercases and deduplicates a hashtag list from
+// ExtractHashtags into the canonical form merged into Meta.Tags by
+// OSStore.
+func normalizeHashtags(raw []string) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(raw))
+	for _, t := range raw {
+		if t == "" {
+			continue
+		}
+		set[strings.ToLower(t)] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for t := range set {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
## Summary

- Split `note/storage.go` and `note/store.go` by responsibility so the filenames reflect their contents: `store.go` keeps the `Store` interface + `ErrNotFound`; the query/filter machinery moves to `query.go`; `ValidateSlug` + `slugRe` move to `slug.go`; tag helpers (`hasAllTags`, `computeMergedTags`, `normalizeHashtags`) merge into `tags.go` next to `ExtractHashtags`.
- No behavior change — pure file reorganization. `make lint`, `make test`, `go build`, `go vet` all pass.