### PR TITLE
Simplify Task parsing: Done bool + stricter regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [0.3.18] - 2026-04-24
 
-### Removed
+### Changed
 
-- `note.TaskState`, the `TaskPending` / `TaskDone` / `TaskOther` constants, `markerToState`, and the `Task.State` field — nothing read `State`; `RolloverTasks` already switches on `Task.marker` and `IsDaily` directly ([#248]).
+- Replace `Task.State` (`TaskState` enum with `TaskPending` / `TaskDone` / `TaskOther`) with a plain `Task.Done bool` set to `true` when the marker is `+` or `x`. Drops the unused `TaskOther` value and the `markerToState` helper ([#248]).
 
 [#248]: https://github.com/dreikanter/notes-cli/pull/248
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Changed
 
-- Replace `Task.State` (`TaskState` enum with `TaskPending` / `TaskDone` / `TaskOther`) with a plain `Task.Done bool` set to `true` when the marker is `+` or `x`. Drops the unused `TaskOther` value and the `markerToState` helper ([#248]).
+- Replace `Task.State` (`TaskState` enum with `TaskPending` / `TaskDone` / `TaskOther`) with a plain `Task.Done bool`. Drops the unused `TaskOther` value and the `markerToState` helper.
+- Tighten `taskRe` to require the canonical `- ` bullet prefix and only accept ` ` or `x` as the marker character; `[+]` and unprefixed `[ ]` lines are no longer recognised as tasks ([#248]).
 
 [#248]: https://github.com/dreikanter/notes-cli/pull/248
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.18] - 2026-04-24
+
+### Removed
+
+- `note.TaskState`, the `TaskPending` / `TaskDone` / `TaskOther` constants, `markerToState`, and the `Task.State` field — nothing read `State`; `RolloverTasks` already switches on `Task.marker` and `IsDaily` directly ([#248]).
+
+[#248]: https://github.com/dreikanter/notes-cli/pull/248
+
 ## [0.3.17] - 2026-04-24
 
 ### Changed

--- a/note/todo.go
+++ b/note/todo.go
@@ -5,14 +5,14 @@ import (
 	"strings"
 )
 
-// taskRe matches lines like "  - [ ] some task" or "[ ] some task".
-var taskRe = regexp.MustCompile(`^(\s*(?:- )?\[)(.)(\].*)$`)
+// taskRe matches lines like "- [ ] some task" or "  - [x] some task".
+var taskRe = regexp.MustCompile(`^(\s*- \[)( |x)(\].*)$`)
 
 // Task represents a parsed task line from a todo note.
 type Task struct {
 	Line       string // original full line
 	Text       string // trimmed task text, e.g. "Buy milk #daily"
-	Done       bool   // true when the marker is "+" or "x"
+	Done       bool   // true when the marker is "x"
 	IsDaily    bool   // whether line contains #daily
 	IsMoved    bool   // whether line contains (moved)
 	LineNumber int    // 0-based index in the source file lines
@@ -39,7 +39,7 @@ func ParseTask(line string, lineNumber int) *Task {
 	return &Task{
 		Line:       line,
 		Text:       text,
-		Done:       m[2] == "+" || m[2] == "x",
+		Done:       m[2] == "x",
 		IsDaily:    strings.Contains(line, "#daily"),
 		IsMoved:    strings.Contains(line, "(moved)"),
 		LineNumber: lineNumber,

--- a/note/todo.go
+++ b/note/todo.go
@@ -12,6 +12,7 @@ var taskRe = regexp.MustCompile(`^(\s*(?:- )?\[)(.)(\].*)$`)
 type Task struct {
 	Line       string // original full line
 	Text       string // trimmed task text, e.g. "Buy milk #daily"
+	Done       bool   // true when the marker is "+" or "x"
 	IsDaily    bool   // whether line contains #daily
 	IsMoved    bool   // whether line contains (moved)
 	LineNumber int    // 0-based index in the source file lines
@@ -38,6 +39,7 @@ func ParseTask(line string, lineNumber int) *Task {
 	return &Task{
 		Line:       line,
 		Text:       text,
+		Done:       m[2] == "+" || m[2] == "x",
 		IsDaily:    strings.Contains(line, "#daily"),
 		IsMoved:    strings.Contains(line, "(moved)"),
 		LineNumber: lineNumber,

--- a/note/todo.go
+++ b/note/todo.go
@@ -5,45 +5,21 @@ import (
 	"strings"
 )
 
-// TaskState describes the completion state of a task line.
-type TaskState string
-
-const (
-	// TaskPending is an incomplete task (marker " ").
-	TaskPending TaskState = "pending"
-	// TaskDone is a completed task (marker "+" or "x").
-	TaskDone TaskState = "done"
-	// TaskOther covers any marker character not mapped above.
-	TaskOther TaskState = "other"
-)
-
 // taskRe matches lines like "  - [ ] some task" or "[ ] some task".
 var taskRe = regexp.MustCompile(`^(\s*(?:- )?\[)(.)(\].*)$`)
 
 // Task represents a parsed task line from a todo note.
 type Task struct {
-	Line       string    // original full line
-	State      TaskState // completion state derived from the marker
-	Text       string    // trimmed task text, e.g. "Buy milk #daily"
-	IsDaily    bool      // whether line contains #daily
-	IsMoved    bool      // whether line contains (moved)
-	LineNumber int       // 0-based index in the source file lines
+	Line       string // original full line
+	Text       string // trimmed task text, e.g. "Buy milk #daily"
+	IsDaily    bool   // whether line contains #daily
+	IsMoved    bool   // whether line contains (moved)
+	LineNumber int    // 0-based index in the source file lines
 
 	// regex capture groups kept unexported; use Reassembled / WithTag to rebuild lines.
 	prefix string
 	marker string
 	suffix string
-}
-
-func markerToState(m string) TaskState {
-	switch m {
-	case " ":
-		return TaskPending
-	case "+", "x":
-		return TaskDone
-	default:
-		return TaskOther
-	}
 }
 
 // ParseTask attempts to parse a line as a task. Returns nil if not a task line.
@@ -61,7 +37,6 @@ func ParseTask(line string, lineNumber int) *Task {
 	}
 	return &Task{
 		Line:       line,
-		State:      markerToState(m[2]),
 		Text:       text,
 		IsDaily:    strings.Contains(line, "#daily"),
 		IsMoved:    strings.Contains(line, "(moved)"),

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -7,27 +7,26 @@ import (
 
 func TestParseTask(t *testing.T) {
 	tests := []struct {
-		name      string
-		line      string
-		wantNil   bool
-		wantState TaskState
-		isDaily   bool
-		isMoved   bool
+		name    string
+		line    string
+		wantNil bool
+		isDaily bool
+		isMoved bool
 	}{
-		{"pending", "[ ] Buy milk", false, TaskPending, false, false},
-		{"pending with bullet", "- [ ] Buy milk", false, TaskPending, false, false},
-		{"pending indented", "  [ ] Buy milk", false, TaskPending, false, false},
-		{"pending indented bullet", "  - [ ] Buy milk", false, TaskPending, false, false},
-		{"completed plus", "[+] Done task", false, TaskDone, false, false},
-		{"completed x", "[x] Done task", false, TaskDone, false, false},
-		{"daily", "[ ] Standup #daily", false, TaskPending, true, false},
-		{"daily completed", "[+] Standup #daily", false, TaskDone, true, false},
-		{"moved", "- [ ] (moved) Buy milk", false, TaskPending, false, true},
-		{"moved with other tag", "- [ ] (moved) (private) Do thing", false, TaskPending, false, true},
-		{"not a task", "Just a regular line", true, "", false, false},
-		{"empty", "", true, "", false, false},
-		{"header", "# Todo", true, "", false, false},
-		{"frontmatter", "---", true, "", false, false},
+		{"pending", "[ ] Buy milk", false, false, false},
+		{"pending with bullet", "- [ ] Buy milk", false, false, false},
+		{"pending indented", "  [ ] Buy milk", false, false, false},
+		{"pending indented bullet", "  - [ ] Buy milk", false, false, false},
+		{"completed plus", "[+] Done task", false, false, false},
+		{"completed x", "[x] Done task", false, false, false},
+		{"daily", "[ ] Standup #daily", false, true, false},
+		{"daily completed", "[+] Standup #daily", false, true, false},
+		{"moved", "- [ ] (moved) Buy milk", false, false, true},
+		{"moved with other tag", "- [ ] (moved) (private) Do thing", false, false, true},
+		{"not a task", "Just a regular line", true, false, false},
+		{"empty", "", true, false, false},
+		{"header", "# Todo", true, false, false},
+		{"frontmatter", "---", true, false, false},
 	}
 
 	for _, tt := range tests {
@@ -41,9 +40,6 @@ func TestParseTask(t *testing.T) {
 			}
 			if task == nil {
 				t.Fatalf("expected non-nil for %q", tt.line)
-			}
-			if task.State != tt.wantState {
-				t.Errorf("state: got %q, want %q", task.State, tt.wantState)
 			}
 			if task.IsDaily != tt.isDaily {
 				t.Errorf("isDaily: got %v, want %v", task.IsDaily, tt.isDaily)

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -14,16 +14,15 @@ func TestParseTask(t *testing.T) {
 		isDaily bool
 		isMoved bool
 	}{
-		{"pending", "[ ] Buy milk", false, false, false, false},
-		{"pending with bullet", "- [ ] Buy milk", false, false, false, false},
-		{"pending indented", "  [ ] Buy milk", false, false, false, false},
-		{"pending indented bullet", "  - [ ] Buy milk", false, false, false, false},
-		{"completed plus", "[+] Done task", false, true, false, false},
-		{"completed x", "[x] Done task", false, true, false, false},
-		{"daily", "[ ] Standup #daily", false, false, true, false},
-		{"daily completed", "[+] Standup #daily", false, true, true, false},
+		{"pending", "- [ ] Buy milk", false, false, false, false},
+		{"pending indented", "  - [ ] Buy milk", false, false, false, false},
+		{"completed", "- [x] Done task", false, true, false, false},
+		{"daily", "- [ ] Standup #daily", false, false, true, false},
+		{"daily completed", "- [x] Standup #daily", false, true, true, false},
 		{"moved", "- [ ] (moved) Buy milk", false, false, false, true},
 		{"moved with other tag", "- [ ] (moved) (private) Do thing", false, false, false, true},
+		{"no bullet", "[ ] Buy milk", true, false, false, false},
+		{"unknown marker", "- [+] Done", true, false, false, false},
 		{"not a task", "Just a regular line", true, false, false, false},
 		{"empty", "", true, false, false, false},
 		{"header", "# Todo", true, false, false, false},
@@ -60,10 +59,10 @@ func TestParseTaskText(t *testing.T) {
 		line string
 		want string
 	}{
-		{"[ ] Buy milk", "Buy milk"},
+		{"- [ ] Buy milk", "Buy milk"},
 		{"- [ ] Buy milk #daily", "Buy milk #daily"},
 		{"  - [ ] (moved) Do thing", "(moved) Do thing"},
-		{"[+] Done", "Done"},
+		{"- [x] Done", "Done"},
 	}
 	for _, tt := range tests {
 		task := ParseTask(tt.line, 0)
@@ -81,8 +80,8 @@ func TestReassembled(t *testing.T) {
 	if task == nil {
 		t.Fatal("expected task")
 	}
-	got := task.Reassembled("+")
-	want := "  - [+] Some task"
+	got := task.Reassembled("x")
+	want := "  - [x] Some task"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -97,7 +96,6 @@ func TestWithTag(t *testing.T) {
 	}{
 		{"simple", "- [ ] Do the thing", "moved", "- [ ] (moved) Do the thing"},
 		{"with existing tag", "- [ ] (private) Do the thing", "moved", "- [ ] (moved) (private) Do the thing"},
-		{"no bullet", "[ ] Do the thing", "moved", "[ ] (moved) Do the thing"},
 		{"indented", "  - [ ] Do the thing", "moved", "  - [ ] (moved) Do the thing"},
 		{"already tagged", "- [ ] (moved) Do the thing", "moved", "- [ ] (moved) Do the thing"},
 		{"already tagged with other", "- [ ] (moved) (private) Do the thing", "moved", "- [ ] (moved) (private) Do the thing"},
@@ -121,13 +119,13 @@ func TestRolloverTasks(t *testing.T) {
 slug: todo
 ---
 
-[ ] Pending task one
+- [ ] Pending task one
 
-[ ] Pending task two
+- [ ] Pending task two
 
-[+] Completed task
+- [x] Completed task
 
-[ ] Standup #daily`, "\n")
+- [ ] Standup #daily`, "\n")
 
 	result := RolloverTasks(prev)
 
@@ -155,11 +153,11 @@ slug: todo
 }
 
 func TestRolloverTasksMovedFormat(t *testing.T) {
-	prev := strings.Split(`[ ] Buy milk
+	prev := strings.Split(`- [ ] Buy milk
 
-[ ] (private) Secret task
+- [ ] (private) Secret task
 
-[+] Completed task`, "\n")
+- [x] Completed task`, "\n")
 
 	result := RolloverTasks(prev)
 
@@ -170,13 +168,13 @@ func TestRolloverTasksMovedFormat(t *testing.T) {
 	// Verify (moved) is inserted before existing tags
 	for _, line := range result.UpdatedLines {
 		if strings.Contains(line, "Buy milk") && strings.Contains(line, "(moved)") {
-			want := "[ ] (moved) Buy milk"
+			want := "- [ ] (moved) Buy milk"
 			if line != want {
 				t.Errorf("got %q, want %q", line, want)
 			}
 		}
 		if strings.Contains(line, "Secret task") && strings.Contains(line, "(moved)") {
-			want := "[ ] (moved) (private) Secret task"
+			want := "- [ ] (moved) (private) Secret task"
 			if line != want {
 				t.Errorf("got %q, want %q", line, want)
 			}
@@ -185,11 +183,11 @@ func TestRolloverTasksMovedFormat(t *testing.T) {
 }
 
 func TestRolloverTasksSkipsMoved(t *testing.T) {
-	prev := strings.Split(`[ ] (moved) Already moved task
+	prev := strings.Split(`- [ ] (moved) Already moved task
 
-[ ] Fresh task
+- [ ] Fresh task
 
-[x] Done task`, "\n")
+- [x] Done task`, "\n")
 
 	result := RolloverTasks(prev)
 
@@ -202,16 +200,16 @@ func TestRolloverTasksSkipsMoved(t *testing.T) {
 
 	// Already-moved task should not be re-tagged
 	for _, line := range result.UpdatedLines {
-		if strings.Contains(line, "Already moved") && line != "[ ] (moved) Already moved task" {
+		if strings.Contains(line, "Already moved") && line != "- [ ] (moved) Already moved task" {
 			t.Errorf("moved task should be unchanged, got: %s", line)
 		}
 	}
 }
 
 func TestRolloverTasksDailyAlwaysCarried(t *testing.T) {
-	prev := strings.Split(`[+] Standup #daily
+	prev := strings.Split(`- [x] Standup #daily
 
-[+] Completed other task`, "\n")
+- [x] Completed other task`, "\n")
 
 	result := RolloverTasks(prev)
 
@@ -225,7 +223,7 @@ func TestRolloverTasksDailyAlwaysCarried(t *testing.T) {
 
 func TestRolloverTasksNoDuplicates(t *testing.T) {
 	// A daily task that is also pending should appear only once
-	prev := strings.Split(`[ ] Standup #daily`, "\n")
+	prev := strings.Split(`- [ ] Standup #daily`, "\n")
 
 	result := RolloverTasks(prev)
 
@@ -239,7 +237,7 @@ func TestRolloverTasksEmpty(t *testing.T) {
 slug: todo
 ---
 
-[+] Everything done`, "\n")
+- [x] Everything done`, "\n")
 
 	result := RolloverTasks(prev)
 
@@ -249,8 +247,8 @@ slug: todo
 }
 
 func TestFormatTodoContent(t *testing.T) {
-	task1 := ParseTask("[ ] Task one", 0)
-	task2 := ParseTask("[ ] Task two", 1)
+	task1 := ParseTask("- [ ] Task one", 0)
+	task2 := ParseTask("- [ ] Task two", 1)
 	if task1 == nil || task2 == nil {
 		t.Fatal("expected tasks")
 	}
@@ -260,14 +258,14 @@ func TestFormatTodoContent(t *testing.T) {
 	if strings.HasPrefix(content, "---") {
 		t.Errorf("unexpected frontmatter, got:\n%s", content)
 	}
-	if !strings.Contains(content, "[ ] Task one") {
+	if !strings.Contains(content, "- [ ] Task one") {
 		t.Error("expected Task one with reset marker")
 	}
-	if !strings.Contains(content, "[ ] Task two") {
+	if !strings.Contains(content, "- [ ] Task two") {
 		t.Error("expected Task two with reset marker")
 	}
 	// Tasks separated by blank lines
-	if !strings.Contains(content, "[ ] Task one\n\n[ ] Task two") {
+	if !strings.Contains(content, "- [ ] Task one\n\n- [ ] Task two") {
 		t.Errorf("tasks should be separated by blank lines, got:\n%s", content)
 	}
 }

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -10,23 +10,24 @@ func TestParseTask(t *testing.T) {
 		name    string
 		line    string
 		wantNil bool
+		done    bool
 		isDaily bool
 		isMoved bool
 	}{
-		{"pending", "[ ] Buy milk", false, false, false},
-		{"pending with bullet", "- [ ] Buy milk", false, false, false},
-		{"pending indented", "  [ ] Buy milk", false, false, false},
-		{"pending indented bullet", "  - [ ] Buy milk", false, false, false},
-		{"completed plus", "[+] Done task", false, false, false},
-		{"completed x", "[x] Done task", false, false, false},
-		{"daily", "[ ] Standup #daily", false, true, false},
-		{"daily completed", "[+] Standup #daily", false, true, false},
-		{"moved", "- [ ] (moved) Buy milk", false, false, true},
-		{"moved with other tag", "- [ ] (moved) (private) Do thing", false, false, true},
-		{"not a task", "Just a regular line", true, false, false},
-		{"empty", "", true, false, false},
-		{"header", "# Todo", true, false, false},
-		{"frontmatter", "---", true, false, false},
+		{"pending", "[ ] Buy milk", false, false, false, false},
+		{"pending with bullet", "- [ ] Buy milk", false, false, false, false},
+		{"pending indented", "  [ ] Buy milk", false, false, false, false},
+		{"pending indented bullet", "  - [ ] Buy milk", false, false, false, false},
+		{"completed plus", "[+] Done task", false, true, false, false},
+		{"completed x", "[x] Done task", false, true, false, false},
+		{"daily", "[ ] Standup #daily", false, false, true, false},
+		{"daily completed", "[+] Standup #daily", false, true, true, false},
+		{"moved", "- [ ] (moved) Buy milk", false, false, false, true},
+		{"moved with other tag", "- [ ] (moved) (private) Do thing", false, false, false, true},
+		{"not a task", "Just a regular line", true, false, false, false},
+		{"empty", "", true, false, false, false},
+		{"header", "# Todo", true, false, false, false},
+		{"frontmatter", "---", true, false, false, false},
 	}
 
 	for _, tt := range tests {
@@ -40,6 +41,9 @@ func TestParseTask(t *testing.T) {
 			}
 			if task == nil {
 				t.Fatalf("expected non-nil for %q", tt.line)
+			}
+			if task.Done != tt.done {
+				t.Errorf("done: got %v, want %v", task.Done, tt.done)
 			}
 			if task.IsDaily != tt.isDaily {
 				t.Errorf("isDaily: got %v, want %v", task.IsDaily, tt.isDaily)


### PR DESCRIPTION
## Summary

- Replace `Task.State` (the `TaskState` enum with `TaskPending` / `TaskDone` / `TaskOther`) with a plain `Task.Done bool`. Drops the unused `TaskOther` value and the `markerToState` helper.
- Tighten `taskRe` from `^(\s*(?:- )?\[)(.)(\].*)$` to `^(\s*- \[)( |x)(\].*)$`: the `- ` bullet is now required and the marker must be ` ` or `x`. The previously-tolerated `[+]` marker and bullet-less `[ ] task` form are no longer recognised, matching the canonical format the CLI already produces.
- Tests updated to use the canonical `- [ ] …` / `- [x] …` form; two new negative cases cover the bullet-less and `[+]` rejections.