### PR TITLE
ci: tag releases from CHANGELOG.md instead of auto-incrementing

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,15 +15,17 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Bump patch version and push tag
+      - name: Tag from CHANGELOG
         run: |
-          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          if [ -z "$LATEST" ]; then
-            NEXT="v0.2.0"
-          else
-            MAJOR_MINOR=$(echo "$LATEST" | cut -d. -f1,2)
-            PATCH=$(echo "$LATEST" | cut -d. -f3)
-            NEXT="$MAJOR_MINOR.$((PATCH + 1))"
+          VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '[]' | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "No version heading found in CHANGELOG.md" >&2
+            exit 1
+          fi
+          NEXT="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$NEXT" >/dev/null; then
+            echo "Tag $NEXT already exists; skipping"
+            exit 0
           fi
           git tag "$NEXT"
           git push origin "$NEXT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.19] - 2026-04-24
+
+### Changed
+
+- `.github/workflows/tag.yml` now tags merged PRs using the topmost `## [X.Y.Z]` heading from `CHANGELOG.md` instead of auto-incrementing the patch off the latest git tag. This resyncs git tags with CHANGELOG versions (which had drifted — tags were stuck at `v0.1.x` while the CHANGELOG had advanced to `0.3.x`). `CLAUDE.md` versioning/changelog sections updated accordingly ([#249]).
+
+[#249]: https://github.com/dreikanter/notes-cli/pull/249
+
 ## [0.3.18] - 2026-04-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -509,52 +509,24 @@ No implementations and no behaviour changes — this PR only establishes the con
 
 - `notes read`, `notes append`, and `notes resolve` now include the effective filters in the "no notes found" error (e.g. `no notes found matching filters: type=[todo] today=true`) so you can tell which filter narrowed too far ([#115])
 - `notes new` and `notes new-todo` now inherit the notes-store root's directory permissions when creating date subdirectories, instead of hardcoding `0o755`, so a `0o700` root is no longer silently widened ([#115])
-
-### Removed
-
-- `notes read --no-frontmatter` no longer has a `-F` short form. Use the long flag ([#115])
-
-## [0.1.83] - 2026-04-20
-
-### Changed
-
 - `note.NextID` now flocks the store root directory instead of a sibling `id.json.lock` file, so no lockfile artifact is left behind after `notes new` / `notes new-todo` runs. Serialization semantics are unchanged ([#115])
 - `notes annotate --timeout 0` now disables the deadline (previously it caused the command to fail immediately), mirroring `--max-chars 0 = no limit` ([#115])
-
-## [0.1.82] - 2026-04-20
-
-### Changed
-
 - `note.NextID` now serializes the id.json read-modify-write across processes via an exclusive `flock` on a sibling `id.json.lock`, so parallel `notes new` / `notes new-todo` runs can no longer duplicate IDs ([#115])
 - `notes grep` and `notes rg` propagate the child process's exit code instead of collapsing every failure to `1`: "no match" (exit 1) is now distinguishable from real tool errors (exit 2+) by the caller ([#115])
 - `notes annotate` now runs the `claude` CLI with a context-bound timeout (default 60s, configurable via `--timeout`), so a hung Claude binary no longer hangs the command indefinitely ([#115])
-
-## [0.1.81] - 2026-04-20
-
-### Changed
-
 - `notes update --sync-filename` now reserves the target atomically with `os.Link` + `os.Remove`, closing a TOCTOU between `os.Stat` and `os.Rename` that could silently clobber a file created between the two syscalls ([#115])
 - `mustNotesPath` replaced by `notesRoot() (string, error)`: the notes-store resolution no longer calls `os.Exit(1)` from inside `RunE` handlers, so errors now flow through Cobra's normal error pipeline (and respect `SilenceUsage`). Error output and exit code are unchanged ([#115])
 - `notes annotate` error messages are more useful when the `claude` CLI fails with empty stderr: the exit code and the first 500 bytes of stdout are now included, replacing the previous opaque `exit status 1`. Successful runs and failures that write to stderr are unchanged ([#115])
 - `notes new --public` and `--private` are now mutually exclusive (matching `notes update`). Passing both returns an error instead of silently letting `--private` override `--public`; the old silent-override logic is gone ([#115])
-
-### Removed
-
-- `notes new-todo --force` flag has been removed. Its help text promised to "regenerate today's todo even if it exists," but it actually allocated a new ID and wrote a *second* todo for the same day, which was never the intended behavior. If today's todo already exists, `notes new-todo` now unconditionally returns its path ([#115])
-
-## [0.1.80] - 2026-04-20
-
-### Changed
-
 - `notes grep` no longer injects `-i`; searches are case-sensitive by default. Pass `-i` explicitly for case-insensitive search ([#115])
 - `notes rg` now only injects `--glob *.md`; the previously forced `--sortr path`, `--heading`, `--no-line-number`, and `--ignore-case` defaults are gone, so the subcommand behaves like plain `rg` restricted to Markdown files. Pass those flags explicitly if you want the old output style ([#115])
 - `ValidateSlug` now rejects anything outside `[A-Za-z0-9_-]` (previously only all-digit slugs were rejected), so slugs containing `/`, `\`, `.`, whitespace, or control characters can no longer reach `NoteFilename` and corrupt filesystem paths or the filename's dot-suffix cache ([#115])
-
-## [0.1.79] - 2026-04-20
-
-### Changed
-
 - Internal cleanups from the code-review follow-up list (no user-visible behavior change): `notes update`'s "at least one flag" guard now walks `cmd.LocalFlags()` instead of a hand-maintained flag-name slice that had to stay in sync with registrations; `ParseTask`'s regex requires exactly one marker character (`[ ]`, `[x]`, …) instead of accepting zero-or-one, so stray `[]` no longer parses as a task ([#115])
+
+### Removed
+
+- `notes read --no-frontmatter` no longer has a `-F` short form. Use the long flag ([#115])
+- `notes new-todo --force` flag has been removed. Its help text promised to "regenerate today's todo even if it exists," but it actually allocated a new ID and wrote a *second* todo for the same day, which was never the intended behavior. If today's todo already exists, `notes new-todo` now unconditionally returns its path ([#115])
 
 ## [0.1.78] - 2026-04-20
 
@@ -700,6 +672,7 @@ No implementations and no behaviour changes — this PR only establishes the con
 
 - Merge `latest` into `resolve`; `resolve` now accepts `--type`, `--slug`, `--tag` filter flags as an alternative to the positional argument ([#85])
 - Unify `Use` line to `<id|type|query>` across all ref-accepting commands ([#88])
+- Simplify `--slug` flag to single-value on `ls` and `resolve` commands ([#85])
 
 ### Removed
 
@@ -708,16 +681,6 @@ No implementations and no behaviour changes — this PR only establishes the con
 ### Fixed
 
 - Fix broken `edit` and `rm` tests after testdata rename in [#72] ([#85])
-
-## [0.1.54] - 2026-04-05
-
-### Changed
-
-- Simplify `--slug` flag to single-value on `ls` and `resolve` commands ([#85])
-
-### Fixed
-
-- Fix broken tests for `edit` and `rm` commands after testdata rename in [#72] ([#85])
 
 ## [0.1.41] - 2026-04-05
 
@@ -946,7 +909,6 @@ No implementations and no behaviour changes — this PR only establishes the con
 [0.1.58]: https://github.com/dreikanter/notes-cli/releases/tag/v0.1.58
 [0.1.57]: https://github.com/dreikanter/notes-cli/releases/tag/v0.1.57
 [0.1.55]: https://github.com/dreikanter/notes-cli/releases/tag/v0.1.55
-[0.1.54]: https://github.com/dreikanter/notes-cli/releases/tag/v0.1.54
 [0.1.41]: https://github.com/dreikanter/notes-cli/releases/tag/v0.1.41
 [0.1.40]: https://github.com/dreikanter/notes-cli/releases/tag/v0.1.40
 [0.1.39]: https://github.com/dreikanter/notes-cli/releases/tag/v0.1.39

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@ Version is set at build time via git tags and `-ldflags`. The `Version` var in
 `internal/cli/root.go` defaults to `"dev"` and is overridden by `make install`
 / `make build` using `git describe --tags`.
 
-Patch version auto-increments on each PR merge via GitHub Actions
-(`.github/workflows/tag.yml`), e.g. `v0.2.0` → `v0.2.1`. The major.minor
-pair is carried from the latest tag; bump it by tagging manually (e.g.
-`v0.3.0`) before the next merge.
+On PR merge, GitHub Actions (`.github/workflows/tag.yml`) reads the topmost
+`## [X.Y.Z]` heading from `CHANGELOG.md` and pushes `vX.Y.Z` as a git tag. The
+CHANGELOG is the source of truth for the version — bump major/minor/patch by
+writing the desired heading in the PR.
 
 After merging a PR, reinstall locally:
 
@@ -43,17 +43,17 @@ messages, code comments, issue comments, or anywhere else in the repository.
 
 ## Changelog
 
-Update `CHANGELOG.md` in every PR with an entry for the version that PR will create.
+Update `CHANGELOG.md` in every PR with an entry for the version that PR will
+create. The topmost `## [X.Y.Z]` heading determines the git tag pushed on
+merge.
 
-Each PR merge auto-increments the patch version. To find the next version:
-
-```sh
-git describe --tags   # e.g. v0.2.3 → next PR will be v0.2.4
-```
+To find the next version, check the top of `CHANGELOG.md` and bump the patch
+number (or bump major/minor deliberately). Example: if the top entry is
+`## [0.3.18]`, the next PR's heading is `## [0.3.19]`.
 
 Rules:
 - One entry per PR — do not bundle multiple PRs into one entry
-- Use the exact next patch version as the heading
+- Use a version higher than the current top entry; any untagged version works
 - Reference the PR number (`[#N]`) in the entry and add its link at the bottom
 
 Workflow: the PR number is assigned on creation, so add the CHANGELOG entry as


### PR DESCRIPTION
## Summary

- Git tags had drifted from CHANGELOG versions: tags were stuck at `v0.1.x` (latest `v0.1.151`) while the CHANGELOG had climbed through `0.2.x` to `0.3.18`. The auto-tag workflow only incremented the patch off the latest tag, so manual `## [0.2.0]` / `## [0.3.0]` headings in the CHANGELOG never produced matching tags.
- `.github/workflows/tag.yml` now reads the topmost `## [X.Y.Z]` heading from `CHANGELOG.md` and pushes `vX.Y.Z` on PR merge. If the tag already exists it no-ops.
- `CLAUDE.md` versioning/changelog sections updated: CHANGELOG is the source of truth; bump major/minor/patch by writing the desired heading.