### PR TITLE
Clarify CLI usage and simplify command interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ A command-line tool for managing a plain-text note archive you own entirely.
 Every note is a markdown file in a date-stamped folder (`2026/04/20260405_9522.md`). No database, no proprietary format, no account — just files on disk, synced however you like (Dropbox, git, rsync, nothing at all). The CLI gives you fast, scriptable access to the archive from the terminal:
 
 - **Create** notes with optional title, tags, slug, and type
-- **List and filter** by date, type, tag, or slug
-- **Read, append, search** without leaving the shell
-- **Resolve** any reference (ID, type, substring) to a file path — so the tool composes with everything Unix already has
+- **List and filter** by type, tag, slug, or date
+- **Read, append, annotate** without leaving the shell
+- **Resolve** a note (by ID, type, slug, or tag) to an absolute path — so the tool composes with everything Unix already has
 
 The tool doesn't try to be a knowledge graph, a publishing platform, or a second brain app. It covers a deliberately small scope:
 
 1. **Capture** — get text into a file quickly (`echo "..." | notes new`)
-2. **Retrieve** — find it again by ID, type, tag, or full-text search
+2. **Retrieve** — find it again by ID, type, tag, or slug
 3. **Integrate** — pipe notes into other tools, scripts, and AI assistants
 
 Think of it as the storage layer that sits underneath your workflow, not the workflow itself. Obsidian and Logseq are rich GUIs built around their own vaults. Notes CLI is closer to a structured `~/notes` directory with a fast command-line interface on top — no plugins, no sync service, no lock-in. The files are yours; the CLI is optional convenience.
@@ -34,6 +34,11 @@ For development, use `make build` or `make install` from a local clone.
 
 ## Usage
 
+Commands take a note's numeric ID (printed by `new`, `ls`, `resolve`, etc.).
+To act on "the most recent note of type X" or "the most recent note with slug
+Y", use `notes resolve` or `notes ls --limit 1` to turn a filter into an ID
+and compose with shell substitution.
+
 ```sh
 # Create a new note
 notes new
@@ -43,69 +48,67 @@ notes new --type todo --upsert   # create or return existing today's todo
 # Create today's todo (rolls over pending tasks from the previous one)
 notes new-todo
 
-# List notes
+# List note IDs, newest first
 notes ls
 notes ls --limit 10
 notes ls --type todo
-notes ls --type todo --type backlog   # multiple --type flags are ORed
 notes ls --slug meeting
 notes ls --tag work
 notes ls --tag work --tag meeting     # multiple --tag flags are ANDed
-notes ls --name 2026
 notes ls --today
 
-# Resolve a note reference and print its absolute path
-notes resolve 8823               # by ID
-notes resolve todo               # by type (most recent)
-notes resolve meeting            # by path substring (slug, basename, etc.)
-notes resolve --type todo        # by filter flags
-notes resolve --tag work --today
+# Resolve a note and print its absolute path (exactly one lookup flag, or none)
+notes resolve                    # most recent note overall
+notes resolve --id 8823          # by exact numeric ID
+notes resolve --type todo        # most recent note of that type
+notes resolve --slug meeting     # most recent note with that slug
+notes resolve --tag work         # most recent note with that tag
 
-# Note references: any command accepting a ref resolves by ID, type, or path substring
+# Read a note by numeric ID
 notes read 8823
-notes read meeting
-notes read --type todo           # filter flags also work on read
-notes read --type todo --no-frontmatter
-
-# Open a note in $EDITOR
-notes edit todo
-notes edit meeting
+notes read 8823 --no-frontmatter
 
 # Fill empty frontmatter (title, description, tags) using Claude Code CLI
 notes annotate 8823
-notes annotate meeting --model claude-sonnet-4-6
+notes annotate 8823 --model claude-sonnet-4-6
 notes annotate 8823 --max-chars 4000   # truncate body before sending
+notes annotate 8823 --timeout 2m       # override the 60s default
 
 # Append stdin text to a note
 echo "text" | notes append 8823
-echo "text" | notes append --type todo
-echo "text" | notes append --type todo --today
 
 # Delete a note
 notes rm 8823
-notes rm meeting --today
 
-# Update frontmatter (does not rename the file — see --sync-filename below)
+# Update frontmatter (file is renamed automatically when slug, type, or date changes)
 notes update 8823 --title "New Title"
+notes update 8823 --description "One-line summary"
 notes update 8823 --tag work --tag planning
+notes update 8823 --no-tags
 notes update 8823 --slug meeting
 notes update 8823 --no-slug
 notes update 8823 --type todo
 notes update 8823 --no-type
-notes update 8823 --no-tags
+notes update 8823 --date 20260420        # move to a different day (YYYYMMDD)
 notes update 8823 --public
 notes update 8823 --private
 
-# Reconcile filename with frontmatter (slug/type cache)
-notes update 8823 --sync-filename                     # rename to match current fm
-notes update 8823 --slug meeting --sync-filename      # fm change + rename
-
-# Search note contents
-notes grep "search pattern"
-notes rg "search pattern"
-
 # List all tags (frontmatter + body hashtags)
 notes tags
+```
+
+Composing with the shell — since most commands take an ID, use `ls` or
+`resolve` to turn a filter into one:
+
+```sh
+# Append to the most recent note with a given slug
+echo "text" | notes append "$(notes ls --slug claude-sessions --limit 1)"
+
+# Read the most recent todo
+notes read "$(notes ls --type todo --limit 1)"
+
+# Open the most recent meeting note in $EDITOR
+$EDITOR "$(notes resolve --slug meeting)"
 ```
 
 The notes store path is resolved in this order:
@@ -134,19 +137,15 @@ go test ./note/ -run TestParseFilename -v
 
 ## Versioning
 
-Patch version auto-increments on each PR merge to `main` via GitHub Actions
-(e.g. `v0.1.0` → `v0.1.1`). To bump minor or major, edit the version prefix in
-`.github/workflows/tag.yml` and push a manual tag (e.g. `git tag v0.2.0`).
-
-Each PR must include a `CHANGELOG.md` entry for the version it will create. Check
-the next version with `git describe --tags` and increment the patch number.
+`CHANGELOG.md` is the source of truth for the version. On PR merge, GitHub
+Actions (`.github/workflows/tag.yml`) reads the topmost `## [X.Y.Z]` heading
+from `CHANGELOG.md` and pushes `vX.Y.Z` as a git tag. Bump major/minor/patch
+by writing the desired heading in the PR.
 
 After merging, pull and reinstall locally:
 
 ```sh
-git pull --tags
-make install
-notes --version
+make update
 ```
 
 ## License


### PR DESCRIPTION
## Summary

Restructure the README to clarify the command-line interface and simplify how users interact with notes. Key changes:

- **Simplify note resolution**: Commands now take numeric IDs directly. The `resolve` command is repositioned as a utility to convert filters (type, slug, tag) into IDs for shell composition, rather than accepting arbitrary references.
- **Remove ambiguous features**: Drop support for resolving by type/slug/substring in commands like `read` and `append`. These now require explicit numeric IDs.
- **Clarify `annotate` over `search`**: Replace mentions of `grep`/`rg` with `annotate` as the primary content-interaction feature. Remove `--sync-filename` flag documentation (now automatic).
- **Add shell composition examples**: Include practical examples showing how to use `ls` and `resolve` with shell substitution to act on filtered notes.
- **Simplify versioning workflow**: Update versioning docs to reflect that `CHANGELOG.md` is the source of truth, with GitHub Actions reading version from it directly (no manual tag creation needed).

This makes the tool's mental model clearer: IDs are the primary reference mechanism, filters are for discovery, and composition with standard Unix tools is the intended pattern.