### PR TITLE
Use testify assertions in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.22] - 2026-04-25
+
+### Changed
+
+- Add Testify as a direct test dependency and replace hand-written test assertions with `assert` / `require` helpers, reducing test boilerplate without removing coverage ([#255]).
+
 ## [0.3.21] - 2026-04-25
 
 ### Changed
@@ -1054,3 +1060,4 @@ No implementations and no behaviour changes — this PR only establishes the con
 [#167]: https://github.com/dreikanter/notesctl/pull/167
 [#168]: https://github.com/dreikanter/notesctl/pull/168
 [#254]: https://github.com/dreikanter/notesctl/pull/254
+[#255]: https://github.com/dreikanter/notesctl/pull/255

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.7
 require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -157,7 +158,6 @@ require (
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.2.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/tdakkota/asciicheck v0.4.1 // indirect
 	github.com/tetafro/godot v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/tdakkota/asciicheck v0.4.1 h1:bm0tbcmi0jezRA2b5kg4ozmMuGAFotKI3RZfrhfovg8=

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/dreikanter/notesctl/note"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func runAnnotate(t *testing.T, root string, args ...string) (string, error) {
@@ -142,9 +144,7 @@ const annotateSampleEnvelope = `{
 
 func TestParseAnnotationHappyPath(t *testing.T) {
 	res, err := parseAnnotation([]byte(annotateSampleEnvelope))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if res.Title != "Weekly sync" {
 		t.Errorf("title = %q, want %q", res.Title, "Weekly sync")
 	}
@@ -158,31 +158,21 @@ func TestParseAnnotationHappyPath(t *testing.T) {
 
 func TestParseAnnotationInvalidEnvelope(t *testing.T) {
 	_, err := parseAnnotation([]byte("not json"))
-	if err == nil {
-		t.Fatal("expected error for invalid envelope")
-	}
+	require.Error(t, err)
 }
 
 func TestParseAnnotationMissingStructuredOutput(t *testing.T) {
 	bad := `{"type":"result","subtype":"success","is_error":false,"result":"Metadata generated."}`
 	_, err := parseAnnotation([]byte(bad))
-	if err == nil {
-		t.Fatal("expected error when structured_output is absent")
-	}
-	if !strings.Contains(err.Error(), "structured_output") {
-		t.Errorf("error should name structured_output: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "structured_output")
 }
 
 func TestParseAnnotationErrorFlag(t *testing.T) {
 	bad := `{"type":"result","subtype":"error","is_error":true,"result":"something broke"}`
 	_, err := parseAnnotation([]byte(bad))
-	if err == nil {
-		t.Fatal("expected error when is_error=true")
-	}
-	if !strings.Contains(err.Error(), "something broke") {
-		t.Errorf("error message should include server-side message: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "something broke")
 }
 
 func TestMergeAnnotationFillsEmpty(t *testing.T) {
@@ -276,14 +266,10 @@ func TestAnnotateFillsEmptyFields(t *testing.T) {
 	withClaudeBinary(t, writeFakeClaude(t, annotateSampleEnvelope))
 
 	out, err := runAnnotate(t, root, ref)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	want := filepath.Join(root, "2026/04/20260418_9000.md")
-	if out != want {
-		t.Errorf("stdout path = %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 
 	data, err := os.ReadFile(want)
 	if err != nil {
@@ -295,13 +281,9 @@ func TestAnnotateFillsEmptyFields(t *testing.T) {
 		"description: Notes from the weekly team sync.",
 		"tags:\n    - meeting\n    - weekly\n",
 	} {
-		if !strings.Contains(content, s) {
-			t.Errorf("expected %q in file, got:\n%s", s, content)
-		}
+		assert.Contains(t, content, s)
 	}
-	if !strings.Contains(content, "# Weekly sync\n\nDiscussed Q2 roadmap") {
-		t.Errorf("body missing or modified, got:\n%s", content)
-	}
+	assert.Contains(t, content, "# Weekly sync\n\nDiscussed Q2 roadmap")
 }
 
 // noteWithFrontmatter writes a note with the given frontmatter + body and returns (root, ref).
@@ -337,14 +319,10 @@ func TestAnnotateNoOpWhenAllFieldsFilled(t *testing.T) {
 	withClaudeBinary(t, fakeClaudeSentinel(t))
 
 	out, err := runAnnotate(t, root, ref)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	want := filepath.Join(root, "2026/04/20260418_9001.md")
-	if out != want {
-		t.Errorf("stdout = %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 
 	data, _ := os.ReadFile(want)
 	if string(data) != fm+"body content" {
@@ -358,12 +336,8 @@ func TestAnnotateNoBodyErrors(t *testing.T) {
 	withClaudeBinary(t, fakeClaudeSentinel(t))
 
 	_, err := runAnnotate(t, root, ref)
-	if err == nil {
-		t.Fatal("expected error for empty body")
-	}
-	if !strings.Contains(err.Error(), "no body content") {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no body content")
 }
 
 func TestAnnotateClaudeNotFound(t *testing.T) {
@@ -371,12 +345,8 @@ func TestAnnotateClaudeNotFound(t *testing.T) {
 	withClaudeBinary(t, filepath.Join(t.TempDir(), "does-not-exist"))
 
 	_, err := runAnnotate(t, root, ref)
-	if err == nil {
-		t.Fatal("expected error when claude binary missing")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestAnnotateTimeout(t *testing.T) {
@@ -393,9 +363,7 @@ func TestAnnotateTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
-	if !strings.Contains(err.Error(), "timed out") {
-		t.Errorf("expected timeout message, got: %v", err)
-	}
+	assert.Contains(t, err.Error(), "timed out")
 }
 
 // --timeout 0 disables the deadline, so a fake claude that sleeps briefly
@@ -427,12 +395,8 @@ func TestAnnotateClaudeNonZeroExit(t *testing.T) {
 	withClaudeBinary(t, script)
 
 	_, err := runAnnotate(t, root, ref)
-	if err == nil {
-		t.Fatal("expected error on non-zero exit")
-	}
-	if !strings.Contains(err.Error(), "bad things happened") {
-		t.Errorf("stderr not surfaced: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad things happened")
 
 	// File must be untouched.
 	data, _ := os.ReadFile(filepath.Join(root, "2026/04/20260418_9000.md"))
@@ -456,16 +420,10 @@ func TestAnnotateClaudeEmptyStderrIncludesStdout(t *testing.T) {
 	withClaudeBinary(t, script)
 
 	_, err := runAnnotate(t, root, ref)
-	if err == nil {
-		t.Fatal("expected error on non-zero exit")
-	}
+	require.Error(t, err)
 	msg := err.Error()
-	if !strings.Contains(msg, "exit 3") {
-		t.Errorf("expected exit code in error, got: %v", err)
-	}
-	if !strings.Contains(msg, "partial output on stdout") {
-		t.Errorf("expected stdout snippet in error, got: %v", err)
-	}
+	assert.Contains(t, msg, "exit 3")
+	assert.Contains(t, msg, "partial output on stdout")
 }
 
 func TestAnnotateMalformedJSON(t *testing.T) {
@@ -473,12 +431,8 @@ func TestAnnotateMalformedJSON(t *testing.T) {
 	withClaudeBinary(t, writeFakeClaude(t, `not valid json`))
 
 	_, err := runAnnotate(t, root, ref)
-	if err == nil {
-		t.Fatal("expected error for malformed JSON")
-	}
-	if !strings.Contains(err.Error(), "claude response") {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "claude response")
 
 	data, _ := os.ReadFile(filepath.Join(root, "2026/04/20260418_9000.md"))
 	if string(data) != "body text here" {
@@ -512,9 +466,7 @@ func TestAnnotateModelFlagPropagates(t *testing.T) {
 	withClaudeBinary(t, writeFakeClaudeRecording(t, annotateSampleEnvelope, argsPath))
 
 	_, err := runAnnotate(t, root, ref, "--model", "claude-sonnet-4-6")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	data, err := os.ReadFile(argsPath)
 	if err != nil {
@@ -581,9 +533,7 @@ func TestAnnotatePreservesBody(t *testing.T) {
 		t.Fatalf("could not find frontmatter terminator in:\n%s", string(data))
 	}
 	got := string(data)[idx+len("\n---\n\n"):]
-	if got != body {
-		t.Errorf("body modified.\ngot:\n%q\nwant:\n%q", got, body)
-	}
+	assert.Equal(t, body, got)
 }
 
 func TestAnnotateMaxCharsTruncates(t *testing.T) {
@@ -593,9 +543,7 @@ func TestAnnotateMaxCharsTruncates(t *testing.T) {
 	withClaudeBinary(t, writeFakeClaudeRecording(t, annotateSampleEnvelope, argsPath))
 
 	_, err := runAnnotate(t, root, ref, "--max-chars", "100")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	data, err := os.ReadFile(argsPath)
 	if err != nil {
@@ -616,9 +564,7 @@ func TestAnnotateMaxCharsZeroLeavesBodyUntouched(t *testing.T) {
 	withClaudeBinary(t, writeFakeClaudeRecording(t, annotateSampleEnvelope, argsPath))
 
 	_, err := runAnnotate(t, root, ref)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	data, err := os.ReadFile(argsPath)
 	if err != nil {

--- a/internal/cli/append_test.go
+++ b/internal/cli/append_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // copyTestdata copies testdata into a temporary directory so tests
@@ -54,14 +57,10 @@ func runAppend(t *testing.T, root string, stdin string, args ...string) (string,
 func TestAppendByID(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runAppend(t, root, "appended text", "8823")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	want := filepath.Join(root, "2026/01/20260106_8823_999.md")
-	if out != want {
-		t.Errorf("got output %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 
 	data, _ := os.ReadFile(want)
 	if !strings.Contains(string(data), "appended text") {
@@ -72,20 +71,14 @@ func TestAppendByID(t *testing.T) {
 func TestAppendNonIntegerArgErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runAppend(t, root, "text", "meeting")
-	if err == nil {
-		t.Fatal("expected error for non-integer id, got nil")
-	}
+	require.Error(t, err)
 }
 
 func TestAppendNonExistentNote(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runAppend(t, root, "text", "9999")
-	if err == nil {
-		t.Fatal("expected error for non-existent note, got nil")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("expected 'not found', got: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestAppendEmptyStdin(t *testing.T) {
@@ -94,9 +87,7 @@ func TestAppendEmptyStdin(t *testing.T) {
 	before, _ := os.ReadFile(target)
 
 	_, err := runAppend(t, root, "", "8823")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	after, _ := os.ReadFile(target)
 	if string(before) != string(after) {
@@ -110,9 +101,7 @@ func TestAppendWhitespaceOnlyStdin(t *testing.T) {
 	before, _ := os.ReadFile(target)
 
 	_, err := runAppend(t, root, "   \n\n  \t  ", "8823")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	after, _ := os.ReadFile(target)
 	if string(before) != string(after) {
@@ -140,15 +129,11 @@ func TestAppendMultipleProducesSeparation(t *testing.T) {
 	idx1 := strings.Index(content, "first fragment")
 	idx2 := strings.Index(content, "second fragment")
 	between := content[idx1+len("first fragment") : idx2]
-	if !strings.Contains(between, "\n\n") {
-		t.Errorf("fragments not separated by blank line, got between: %q", between)
-	}
+	assert.Contains(t, between, "\n\n")
 }
 
 func TestAppendNoArgErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runAppend(t, root, "text")
-	if err == nil {
-		t.Fatal("expected error when no target specified, got nil")
-	}
+	require.Error(t, err)
 }

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func runLs(t *testing.T, args ...string) (string, error) {
@@ -24,9 +26,7 @@ func runLs(t *testing.T, args ...string) (string, error) {
 
 func TestLsNoArgs(t *testing.T) {
 	out, err := runLs(t)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) != 4 {
@@ -41,9 +41,7 @@ func TestLsNoArgs(t *testing.T) {
 
 func TestLsWithTag(t *testing.T) {
 	out, err := runLs(t, "--tag", "work")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) != 3 {
@@ -53,9 +51,7 @@ func TestLsWithTag(t *testing.T) {
 
 func TestLsWithTagMixedCase(t *testing.T) {
 	out, err := runLs(t, "--tag", "WORK")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) != 3 {
@@ -65,9 +61,7 @@ func TestLsWithTagMixedCase(t *testing.T) {
 
 func TestLsTagNoMatch(t *testing.T) {
 	out, err := runLs(t, "--tag", "nonexistent")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	if out != "" {
 		t.Errorf("expected empty output, got %q", out)
@@ -76,9 +70,7 @@ func TestLsTagNoMatch(t *testing.T) {
 
 func TestLsTagAndType(t *testing.T) {
 	out, err := runLs(t, "--tag", "work", "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) != 1 {
@@ -91,9 +83,7 @@ func TestLsTagAndType(t *testing.T) {
 
 func TestLsTagAndLimit(t *testing.T) {
 	out, err := runLs(t, "--tag", "work", "--limit", "1")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) != 1 {
@@ -103,9 +93,7 @@ func TestLsTagAndLimit(t *testing.T) {
 
 func TestLsMultipleTagsAND(t *testing.T) {
 	out, err := runLs(t, "--tag", "work", "--tag", "planning")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) != 1 {
@@ -118,9 +106,7 @@ func TestLsMultipleTagsAND(t *testing.T) {
 
 func TestLsMultipleTagsCommaSeparated(t *testing.T) {
 	out, err := runLs(t, "--tag", "work,meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) != 1 {
@@ -133,9 +119,7 @@ func TestLsMultipleTagsCommaSeparated(t *testing.T) {
 
 func TestLsTagAndTypeNoOverlap(t *testing.T) {
 	out, err := runLs(t, "--tag", "meeting", "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	if out != "" {
 		t.Errorf("expected empty output (no todo with meeting tag), got %q", out)
@@ -145,9 +129,7 @@ func TestLsTagAndTypeNoOverlap(t *testing.T) {
 func TestLsToday(t *testing.T) {
 	// testdata notes are all in the past; --today should return nothing
 	out, err := runLs(t, "--today")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if out != "" {
 		t.Errorf("expected empty output for --today on past testdata, got %q", out)
 	}
@@ -155,9 +137,7 @@ func TestLsToday(t *testing.T) {
 
 func TestLsUnlimitedByDefault(t *testing.T) {
 	out, err := runLs(t)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) != 4 {
@@ -167,9 +147,7 @@ func TestLsUnlimitedByDefault(t *testing.T) {
 
 func TestLsOutputsIntegerIDs(t *testing.T) {
 	out, err := runLs(t)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	for _, line := range strings.Split(out, "\n") {
 		if line == "" {
@@ -183,9 +161,7 @@ func TestLsOutputsIntegerIDs(t *testing.T) {
 
 func TestLsSlug(t *testing.T) {
 	out, err := runLs(t, "--slug", "meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	lines := strings.Split(out, "\n")
 	if len(lines) != 1 {

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func runNew(t *testing.T, root string, stdin string, args ...string) (string, error) {
@@ -27,9 +30,7 @@ func runNew(t *testing.T, root string, stdin string, args ...string) (string, er
 func TestNewDefault(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if !strings.HasPrefix(out, root) {
 		t.Errorf("expected path under root, got %q", out)
 	}
@@ -41,104 +42,70 @@ func TestNewDefault(t *testing.T) {
 func TestNewWithSlug(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "", "--slug", "myslug")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(filepath.Base(out), "_myslug") {
-		t.Errorf("expected slug in filename, got %q", filepath.Base(out))
-	}
+	require.NoError(t, err)
+	assert.Contains(t, filepath.Base(out), "_myslug")
 	data, err := os.ReadFile(out)
 	if err != nil {
 		t.Fatalf("read note: %v", err)
 	}
-	if !strings.Contains(string(data), "slug: myslug") {
-		t.Errorf("expected slug in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "slug: myslug")
 }
 
 func TestNewWithType(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "", "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(filepath.Base(out), ".todo.") {
-		t.Errorf("expected type in filename, got %q", filepath.Base(out))
-	}
+	require.NoError(t, err)
+	assert.Contains(t, filepath.Base(out), ".todo.")
 }
 
 func TestNewWithTags(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "", "--tag", "work", "--tag", "daily")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, _ := os.ReadFile(out)
-	if !strings.Contains(string(data), "tags:\n    - work\n    - daily\n") {
-		t.Errorf("expected tags in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "tags:\n    - work\n    - daily\n")
 }
 
 func TestNewWithTitleAndDescription(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "", "--title", "My Note", "--description", "A description")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, _ := os.ReadFile(out)
 	content := string(data)
-	if !strings.Contains(content, "title: My Note") {
-		t.Errorf("expected title in frontmatter, got:\n%s", content)
-	}
-	if !strings.Contains(content, "description: A description") {
-		t.Errorf("expected description in frontmatter, got:\n%s", content)
-	}
+	assert.Contains(t, content, "title: My Note")
+	assert.Contains(t, content, "description: A description")
 }
 
 func TestNewWithPublic(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "", "--public")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, err := os.ReadFile(out)
 	if err != nil {
 		t.Fatalf("read note: %v", err)
 	}
-	if !strings.Contains(string(data), "public: true") {
-		t.Errorf("expected public: true in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "public: true")
 }
 
 func TestNewAllDigitSlugErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runNew(t, root, "", "--slug", "999")
-	if err == nil {
-		t.Fatal("expected error for all-digit slug, got nil")
-	}
+	require.Error(t, err)
 }
 
 func TestNewWithBody(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "hello world\n")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, _ := os.ReadFile(out)
-	if !strings.Contains(string(data), "hello world") {
-		t.Errorf("expected body content in file, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "hello world")
 }
 
 func TestNewUpsertCreatesWhenNoMatch(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "", "--slug", "report", "--upsert")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(filepath.Base(out), "_report") {
-		t.Errorf("expected slug in filename, got %s", filepath.Base(out))
-	}
+	require.NoError(t, err)
+	assert.Contains(t, filepath.Base(out), "_report")
 	if _, err := os.Stat(out); err != nil {
 		t.Errorf("created file does not exist: %v", err)
 	}
@@ -159,9 +126,7 @@ func TestNewUpsertReturnsExisting(t *testing.T) {
 		t.Fatalf("unexpected error on second call: %v", err)
 	}
 
-	if first != second {
-		t.Errorf("expected same path, got %q and %q", first, second)
-	}
+	assert.Equal(t, second, first)
 }
 
 func TestNewUpsertByType(t *testing.T) {
@@ -177,17 +142,13 @@ func TestNewUpsertByType(t *testing.T) {
 		t.Fatalf("unexpected error on second call: %v", err)
 	}
 
-	if first != second {
-		t.Errorf("expected same path, got %q and %q", first, second)
-	}
+	assert.Equal(t, second, first)
 }
 
 func TestNewUpsertWithoutFilterErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runNew(t, root, "", "--upsert")
-	if err == nil {
-		t.Fatal("expected error when --upsert used without --type or --slug, got nil")
-	}
+	require.Error(t, err)
 }
 
 func TestNewWithoutUpsertAlwaysCreates(t *testing.T) {
@@ -211,32 +172,22 @@ func TestNewWithoutUpsertAlwaysCreates(t *testing.T) {
 func TestNewWithCustomType(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "", "--type", "meeting", "--slug", "sync")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(filepath.Base(out), "sync.meeting.md") {
-		t.Errorf("expected slug+type cache in filename, got %q", filepath.Base(out))
-	}
+	require.NoError(t, err)
+	assert.Contains(t, filepath.Base(out), "sync.meeting.md")
 	data, err := os.ReadFile(out)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	if !strings.Contains(string(data), "type: meeting") {
-		t.Errorf("expected type: meeting in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "type: meeting")
 }
 
 func TestNewWithKnownTypeStillWrites(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "", "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if !strings.HasSuffix(filepath.Base(out), ".todo.md") {
 		t.Errorf("expected .todo.md suffix, got %q", filepath.Base(out))
 	}
 	data, _ := os.ReadFile(out)
-	if !strings.Contains(string(data), "type: todo") {
-		t.Errorf("expected type: todo in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "type: todo")
 }

--- a/internal/cli/new_todo_test.go
+++ b/internal/cli/new_todo_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/dreikanter/notesctl/note"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func runNewTodo(t *testing.T, root string, args ...string) (string, error) {
@@ -38,17 +40,11 @@ func emptyNotesRoot(t *testing.T) string {
 func TestNewTodoCreatesFromPrevious(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNewTodo(t, root)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	today := time.Now().Format(note.DateFormat)
-	if !strings.Contains(filepath.Base(out), today) {
-		t.Errorf("expected today's date %s in filename, got %q", today, filepath.Base(out))
-	}
-	if !strings.Contains(filepath.Base(out), ".todo.") {
-		t.Errorf("expected .todo. in filename, got %q", filepath.Base(out))
-	}
+	assert.Contains(t, filepath.Base(out), today)
+	assert.Contains(t, filepath.Base(out), ".todo.")
 	if _, err := os.Stat(out); err != nil {
 		t.Errorf("created file does not exist: %v", err)
 	}
@@ -67,9 +63,7 @@ func TestNewTodoReturnsExistingToday(t *testing.T) {
 		t.Fatalf("second call unexpected error: %v", err)
 	}
 
-	if first != second {
-		t.Errorf("expected same path on second call, got %q then %q", first, second)
-	}
+	assert.Equal(t, second, first)
 }
 
 func TestNewTodoNoPreviousCreatesEmpty(t *testing.T) {
@@ -89,24 +83,18 @@ func TestNewTodoNoPreviousCreatesEmpty(t *testing.T) {
 		t.Fatalf("cannot read created file: %v", err)
 	}
 	content := string(data)
-	if strings.Contains(content, "[ ]") {
-		t.Errorf("expected no tasks in empty todo, got:\n%s", content)
-	}
+	assert.NotContains(t, content, "[ ]")
 }
 
 func TestNewTodoWritesTypeFrontmatter(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNewTodo(t, root)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, err := os.ReadFile(out)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
-	if !strings.Contains(string(data), "type: todo") {
-		t.Errorf("expected type: todo in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "type: todo")
 }
 
 func TestNewTodoRollsOverIncompleteTasks(t *testing.T) {
@@ -130,18 +118,12 @@ func TestNewTodoRollsOverIncompleteTasks(t *testing.T) {
 	}
 
 	out, err := runNewTodo(t, root)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	newData, _ := os.ReadFile(out)
 	newContent := string(newData)
-	if !strings.Contains(newContent, "pending task") {
-		t.Errorf("expected pending task carried over, got:\n%s", newContent)
-	}
-	if strings.Contains(newContent, "finished task") {
-		t.Errorf("completed task should not be carried over, got:\n%s", newContent)
-	}
+	assert.Contains(t, newContent, "pending task")
+	assert.NotContains(t, newContent, "finished task")
 
 	prevData, _ := os.ReadFile(prevPath)
 	if !strings.Contains(string(prevData), "(moved)") {

--- a/internal/cli/read_test.go
+++ b/internal/cli/read_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func runRead(t *testing.T, args ...string) (string, error) {
@@ -25,48 +28,30 @@ func runRead(t *testing.T, args ...string) (string, error) {
 
 func TestReadByID(t *testing.T) {
 	out, err := runRead(t, "8823")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(out, "Plain note") {
-		t.Errorf("expected note content, got: %s", out)
-	}
+	require.NoError(t, err)
+	assert.Contains(t, out, "Plain note")
 }
 
 func TestReadMissingID(t *testing.T) {
 	_, err := runRead(t, "999999")
-	if err == nil {
-		t.Fatal("expected error for non-existent id, got nil")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("error message should mention 'not found', got: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestReadNonIntegerArg(t *testing.T) {
 	_, err := runRead(t, "not-an-id")
-	if err == nil {
-		t.Fatal("expected error for non-integer id, got nil")
-	}
+	require.Error(t, err)
 }
 
 func TestReadNoArgsErrors(t *testing.T) {
 	_, err := runRead(t)
-	if err == nil {
-		t.Fatal("expected error when no positional arg, got nil")
-	}
+	require.Error(t, err)
 }
 
 func TestReadNoFrontmatter(t *testing.T) {
 	out, err := runRead(t, "8818", "--no-frontmatter")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	// Frontmatter should be stripped; "tags:" should not appear
-	if strings.Contains(out, "tags:") {
-		t.Errorf("expected frontmatter stripped, got: %s", out)
-	}
-	if !strings.Contains(out, "Standup notes") {
-		t.Errorf("expected note body, got: %s", out)
-	}
+	assert.NotContains(t, out, "tags:")
+	assert.Contains(t, out, "Standup notes")
 }

--- a/internal/cli/resolve_test.go
+++ b/internal/cli/resolve_test.go
@@ -5,6 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func testdataPath(t *testing.T) string {
@@ -35,91 +38,63 @@ func runResolve(t *testing.T, root string, args ...string) (string, error) {
 func TestResolveNewestNoArgs(t *testing.T) {
 	root := testdataPath(t)
 	out, err := runResolve(t, root)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/01/20260106_8823_999.md")
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestResolveByID(t *testing.T) {
 	root := testdataPath(t)
 	out, err := runResolve(t, root, "--id", "8823")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/01/20260106_8823_999.md")
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestResolveByIDNotFound(t *testing.T) {
 	root := testdataPath(t)
 	_, err := runResolve(t, root, "--id", "99999")
-	if err == nil {
-		t.Fatal("expected error for missing ID")
-	}
+	require.Error(t, err)
 }
 
 func TestResolveByIDNonInteger(t *testing.T) {
 	root := testdataPath(t)
 	_, err := runResolve(t, root, "--id", "notnumber")
-	if err == nil {
-		t.Fatal("expected error for non-integer id")
-	}
+	require.Error(t, err)
 }
 
 func TestResolveBySlug(t *testing.T) {
 	root := testdataPath(t)
 	out, err := runResolve(t, root, "--slug", "meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestResolveByType(t *testing.T) {
 	root := testdataPath(t)
 	out, err := runResolve(t, root, "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/01/20260102_8814.todo.md")
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestResolveByTag(t *testing.T) {
 	root := testdataPath(t)
 	out, err := runResolve(t, root, "--tag", "meeting")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestResolveNoMatchErrors(t *testing.T) {
 	root := testdataPath(t)
 	_, err := runResolve(t, root, "--slug", "nonexistent-slug-xyz")
-	if err == nil {
-		t.Fatal("expected error for no match")
-	}
+	require.Error(t, err)
 }
 
 func TestResolveMultipleFlagsError(t *testing.T) {
 	root := testdataPath(t)
 	_, err := runResolve(t, root, "--id", "1", "--slug", "x")
-	if err == nil {
-		t.Fatal("expected error when combining --id and --slug")
-	}
+	require.Error(t, err)
 }

--- a/internal/cli/rm_test.go
+++ b/internal/cli/rm_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func runRm(t *testing.T, root string, args ...string) (string, error) {
@@ -27,13 +30,9 @@ func TestRmByID(t *testing.T) {
 	target := filepath.Join(root, "2026/01/20260106_8823_999.md")
 
 	out, err := runRm(t, root, "8823")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if out != target {
-		t.Errorf("got %q, want %q", out, target)
-	}
+	assert.Equal(t, target, out)
 
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
 		t.Error("file should have been deleted")
@@ -43,18 +42,12 @@ func TestRmByID(t *testing.T) {
 func TestRmNonExistentErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runRm(t, root, "9999")
-	if err == nil {
-		t.Fatal("expected error for non-existent id, got nil")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("error message should mention 'not found', got: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestRmNonIntegerArgErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runRm(t, root, "meeting")
-	if err == nil {
-		t.Fatal("expected error for non-integer id, got nil")
-	}
+	require.Error(t, err)
 }

--- a/internal/cli/tags_test.go
+++ b/internal/cli/tags_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func runTags(t *testing.T, root string, args ...string) (string, error) {
@@ -34,9 +37,7 @@ func writeTagsTestNote(t *testing.T, root, rel, content string) {
 func TestTagsEmptyStore(t *testing.T) {
 	root := t.TempDir()
 	out, err := runTags(t, root)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if out != "" {
 		t.Fatalf("expected empty output, got %q", out)
 	}
@@ -50,9 +51,7 @@ func TestTagsMergedSourcesSorted(t *testing.T) {
 		"no fm, just #tea and #work.\n")
 
 	out, err := runTags(t, root)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	got := strings.Split(out, "\n")
 	want := []string{"coffee", "planning", "tea", "work"}
 	if len(got) != len(want) {
@@ -71,9 +70,7 @@ func TestTagsLowercased(t *testing.T) {
 		"---\ntags: [Work, PLANNING]\n---\n\nbody with #Coffee and #WORK.\n")
 
 	out, err := runTags(t, root)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	got := strings.Split(out, "\n")
 	want := []string{"coffee", "planning", "work"}
 	if len(got) != len(want) {
@@ -92,12 +89,8 @@ func TestTagsIgnoresCodeBlocks(t *testing.T) {
 		"kept #real\n```\n#should-not-appear\n```\nalso #done\n")
 
 	out, err := runTags(t, root)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if strings.Contains(out, "should-not-appear") {
-		t.Errorf("expected code-block hashtag to be excluded, got:\n%s", out)
-	}
+	require.NoError(t, err)
+	assert.NotContains(t, out, "should-not-appear")
 	if !strings.Contains(out, "real") || !strings.Contains(out, "done") {
 		t.Errorf("expected real and done tags, got:\n%s", out)
 	}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func runUpdate(t *testing.T, root string, args ...string) (string, error) {
@@ -26,15 +29,11 @@ func runUpdate(t *testing.T, root string, args ...string) (string, error) {
 func TestUpdateTagsByID(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--tag", "new1", "--tag", "new2")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	data, _ := os.ReadFile(out)
 	content := string(data)
-	if !strings.Contains(content, "tags:\n    - new1\n    - new2\n") {
-		t.Errorf("expected updated tags in frontmatter, got:\n%s", content)
-	}
+	assert.Contains(t, content, "tags:\n    - new1\n    - new2\n")
 	if strings.Contains(content, "- work") {
 		t.Error("old tags should be gone")
 	}
@@ -43,14 +42,10 @@ func TestUpdateTagsByID(t *testing.T) {
 func TestUpdateNoTags(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--no-tags")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	data, _ := os.ReadFile(out)
-	if strings.Contains(string(data), "tags:") {
-		t.Errorf("expected no tags line in frontmatter, got:\n%s", string(data))
-	}
+	assert.NotContains(t, string(data), "tags:")
 }
 
 // TestUpdateSlugRenamesFile: --slug updates frontmatter AND renames the file.
@@ -59,13 +54,9 @@ func TestUpdateSlugRenamesFile(t *testing.T) {
 	origPath := filepath.Join(root, "2026/01/20260106_8823_999.md")
 
 	out, err := runUpdate(t, root, "8823", "--slug", "renamed")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/01/20260106_8823_renamed.md")
-	if out != want {
-		t.Errorf("got path %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 	if _, err := os.Stat(want); err != nil {
 		t.Errorf("new file does not exist: %v", err)
 	}
@@ -74,22 +65,16 @@ func TestUpdateSlugRenamesFile(t *testing.T) {
 	}
 
 	data, _ := os.ReadFile(want)
-	if !strings.Contains(string(data), "slug: renamed") {
-		t.Errorf("expected slug in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "slug: renamed")
 }
 
 func TestUpdateNoSlugRenamesFile(t *testing.T) {
 	root := copyTestdata(t)
 
 	out, err := runUpdate(t, root, "8818", "--no-slug")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/01/20260104_8818.md")
-	if out != want {
-		t.Errorf("got path %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 	if _, err := os.Stat(filepath.Join(root, "2026/01/20260104_8818_meeting.md")); !os.IsNotExist(err) {
 		t.Errorf("old slugged file should be gone, err=%v", err)
 	}
@@ -100,33 +85,23 @@ func TestUpdateTypeRenamesFile(t *testing.T) {
 	root := copyTestdata(t)
 
 	out, err := runUpdate(t, root, "8823", "--type", "todo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/01/20260106_8823_999.todo.md")
-	if out != want {
-		t.Errorf("got path %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 	if _, err := os.Stat(want); err != nil {
 		t.Errorf("new file missing: %v", err)
 	}
 	data, _ := os.ReadFile(want)
-	if !strings.Contains(string(data), "type: todo") {
-		t.Errorf("expected type in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "type: todo")
 }
 
 func TestUpdateNoTypeRenamesFile(t *testing.T) {
 	root := copyTestdata(t)
 
 	out, err := runUpdate(t, root, "8814", "--no-type")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/01/20260102_8814.md")
-	if out != want {
-		t.Errorf("got path %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 	if _, err := os.Stat(filepath.Join(root, "2026/01/20260102_8814.todo.md")); !os.IsNotExist(err) {
 		t.Errorf("old typed file should be gone, err=%v", err)
 	}
@@ -136,13 +111,9 @@ func TestUpdateDateMovesFile(t *testing.T) {
 	root := copyTestdata(t)
 
 	out, err := runUpdate(t, root, "8823", "--date", "20260301")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	want := filepath.Join(root, "2026/03/20260301_8823_999.md")
-	if out != want {
-		t.Errorf("got path %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 	if _, err := os.Stat(want); err != nil {
 		t.Errorf("new file missing: %v", err)
 	}
@@ -154,21 +125,15 @@ func TestUpdateDateMovesFile(t *testing.T) {
 func TestUpdateDateInvalidFormat(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8823", "--date", "2026-03-01")
-	if err == nil {
-		t.Fatal("expected error for invalid date format")
-	}
+	require.Error(t, err)
 }
 
 func TestUpdateTitle(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--title", "My Title")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, _ := os.ReadFile(out)
-	if !strings.Contains(string(data), "title: My Title") {
-		t.Errorf("expected title in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "title: My Title")
 }
 
 func TestUpdateClearTitle(t *testing.T) {
@@ -181,96 +146,68 @@ func TestUpdateClearTitle(t *testing.T) {
 		t.Fatalf("clear: %v", err)
 	}
 	data, _ := os.ReadFile(out)
-	if strings.Contains(string(data), "title:") {
-		t.Errorf("title should be cleared, got:\n%s", string(data))
-	}
+	assert.NotContains(t, string(data), "title:")
 }
 
 func TestUpdateDescription(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--description", "Some desc")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, _ := os.ReadFile(out)
-	if !strings.Contains(string(data), "description: Some desc") {
-		t.Errorf("expected description in frontmatter, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "description: Some desc")
 }
 
 func TestUpdateNoFlagsErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8823")
-	if err == nil {
-		t.Fatal("expected error when no update flags given")
-	}
+	require.Error(t, err)
 }
 
 func TestUpdateNonExistentNoteErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "9999", "--tag", "x")
-	if err == nil {
-		t.Fatal("expected error for non-existent id")
-	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Errorf("expected 'not found' in error, got: %v", err)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }
 
 func TestUpdateNonIntegerArgErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "meeting", "--tag", "x")
-	if err == nil {
-		t.Fatal("expected error for non-integer id")
-	}
+	require.Error(t, err)
 }
 
 func TestUpdateSlugAndNoSlugConflict(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8818", "--slug", "other", "--no-slug")
-	if err == nil {
-		t.Fatal("expected error when both --slug and --no-slug are set")
-	}
+	require.Error(t, err)
 }
 
 func TestUpdateTagAndNoTagsConflict(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8823", "--tag", "foo", "--no-tags")
-	if err == nil {
-		t.Fatal("expected error when both --tag and --no-tags are set")
-	}
+	require.Error(t, err)
 }
 
 func TestUpdateTypeAndNoTypeConflict(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8814", "--type", "backlog", "--no-type")
-	if err == nil {
-		t.Fatal("expected error when both --type and --no-type are set")
-	}
+	require.Error(t, err)
 }
 
 func TestUpdateBodyPreserved(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--tag", "updated")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, _ := os.ReadFile(out)
-	if !strings.Contains(string(data), "# Plain note") {
-		t.Errorf("body content missing, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "# Plain note")
 }
 
 func TestUpdatePublicSetsPublicField(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runUpdate(t, root, "8823", "--public")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, _ := os.ReadFile(out)
-	if !strings.Contains(string(data), "public: true") {
-		t.Errorf("expected public: true, got:\n%s", string(data))
-	}
+	assert.Contains(t, string(data), "public: true")
 }
 
 func TestUpdatePrivateRemovesPublicField(t *testing.T) {
@@ -279,27 +216,19 @@ func TestUpdatePrivateRemovesPublicField(t *testing.T) {
 		t.Fatalf("pre-set: %v", err)
 	}
 	out, err := runUpdate(t, root, "8823", "--private")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	data, _ := os.ReadFile(out)
-	if strings.Contains(string(data), "public:") {
-		t.Errorf("expected no public field, got:\n%s", string(data))
-	}
+	assert.NotContains(t, string(data), "public:")
 }
 
 func TestUpdatePublicAndPrivateConflict(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8823", "--public", "--private")
-	if err == nil {
-		t.Fatal("expected error when both --public and --private are set")
-	}
+	require.Error(t, err)
 }
 
 func TestUpdateAllDigitSlugErrors(t *testing.T) {
 	root := copyTestdata(t)
 	_, err := runUpdate(t, root, "8823", "--slug", "123")
-	if err == nil {
-		t.Fatal("expected error for all-digit slug")
-	}
+	require.Error(t, err)
 }

--- a/note/frontmatter_test.go
+++ b/note/frontmatter_test.go
@@ -2,10 +2,11 @@ package note
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
 
@@ -73,12 +74,8 @@ func TestParseNoteSuccess(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f, body, err := ParseNote([]byte(tt.input))
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !reflect.DeepEqual(f, tt.want) {
-				t.Errorf("frontmatter: got %+v, want %+v", f, tt.want)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, f)
 			if string(body) != tt.body {
 				t.Errorf("body: got %q, want %q", string(body), tt.body)
 			}
@@ -111,9 +108,7 @@ func TestParseNoteErrors(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			f, _, err := ParseNote([]byte(tt.input))
-			if err == nil {
-				t.Fatalf("expected error, got f=%+v", f)
-			}
+			require.Error(t, err)
 			if !f.IsZero() {
 				t.Errorf("expected zero frontmatter on error, got %+v", f)
 			}
@@ -126,9 +121,7 @@ func TestParseNoteErrors(t *testing.T) {
 func TestParseNoteErrorStillReturnsBody(t *testing.T) {
 	input := []byte("---\npublic: maybe\n---\n\n# Content\n")
 	_, body, err := ParseNote(input)
-	if err == nil {
-		t.Fatal("expected error")
-	}
+	require.Error(t, err)
 	if string(body) != "# Content\n" {
 		t.Errorf("body = %q, want %q", string(body), "# Content\n")
 	}
@@ -137,9 +130,7 @@ func TestParseNoteErrorStillReturnsBody(t *testing.T) {
 func TestParseNoteBodyIsSliceOfInput(t *testing.T) {
 	input := []byte("---\ntitle: T\n---\n\nhello\n")
 	_, body, err := ParseNote(input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if len(body) == 0 {
 		t.Fatal("body is empty")
 	}
@@ -158,9 +149,7 @@ func TestFormatNoteSnapshotAllFields(t *testing.T) {
 	}
 	want := "---\ntitle: T\nslug: s\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
 	got := string(mustFormatNote(t, f, []byte("body\n")))
-	if got != want {
-		t.Errorf("got:\n%q\nwant:\n%q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestFormatNoteEmptyFrontmatter(t *testing.T) {
@@ -187,9 +176,7 @@ func TestRoundtrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parse failed: %v", err)
 			}
-			if !reflect.DeepEqual(gotF, fm) {
-				t.Errorf("frontmatter: got %+v, want %+v", gotF, fm)
-			}
+			assert.Equal(t, fm, gotF)
 			if string(gotBody) != "body\n" {
 				t.Errorf("body: got %q, want %q", string(gotBody), "body\n")
 			}
@@ -237,9 +224,7 @@ func TestStripFrontmatter(t *testing.T) {
 func TestParseNoteCRLFInteriorPreserved(t *testing.T) {
 	input := []byte("---\r\ntitle: T\r\ntags:\r\n  - a\r\n  - b\r\n---\r\n\r\nbody line\r\nsecond\r\n")
 	f, body, err := ParseNote(input)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if f.Title != "T" {
 		t.Errorf("Title = %q", f.Title)
 	}
@@ -300,9 +285,7 @@ func TestFormatNoteExtraPreservedInAlphaOrder(t *testing.T) {
 	out := string(mustFormatNote(t, fm, body))
 	// Reserved "title" first; Extra keys alpha-sorted: alpha, featured, zebra.
 	want := "---\ntitle: T\nalpha: 1\nfeatured: true\nzebra: striped\n---\n\nbody\n"
-	if out != want {
-		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestFormatNoteEmptyFrontmatterWithExtraOnly(t *testing.T) {
@@ -311,9 +294,7 @@ func TestFormatNoteEmptyFrontmatterWithExtraOnly(t *testing.T) {
 	}}
 	want := "---\nfeatured: true\n---\n\nbody\n"
 	got := string(mustFormatNote(t, fm, []byte("body\n")))
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestIsZeroIncludesExtra(t *testing.T) {
@@ -339,9 +320,7 @@ func TestTypeRoundTrips(t *testing.T) {
 	}
 	out := string(mustFormatNote(t, fm, body))
 	want := "---\ntitle: T\ntype: meeting\n---\n\nbody\n"
-	if out != want {
-		t.Errorf("out = %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestTypeFieldOrder(t *testing.T) {
@@ -351,9 +330,7 @@ func TestTypeFieldOrder(t *testing.T) {
 	}
 	got := string(mustFormatNote(t, fm, []byte("body\n")))
 	want := "---\ntitle: T\nslug: s\ntype: meeting\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
-	if got != want {
-		t.Errorf("FormatNote =\n%q\nwant:\n%q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestDateRoundTripDateOnly(t *testing.T) {
@@ -371,9 +348,7 @@ func TestDateRoundTripDateOnly(t *testing.T) {
 	}
 	out := string(mustFormatNote(t, fm, body))
 	wantOut := "---\ntitle: T\ndate: 2026-04-22\n---\n\nbody\n"
-	if out != wantOut {
-		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, wantOut)
-	}
+	assert.Equal(t, wantOut, out)
 }
 
 func TestDateRoundTripRFC3339(t *testing.T) {
@@ -388,9 +363,7 @@ func TestDateRoundTripRFC3339(t *testing.T) {
 	}
 	out := string(mustFormatNote(t, fm, body))
 	wantOut := "---\ntitle: T\ndate: 2026-04-22T15:30:00Z\n---\n\nbody\n"
-	if out != wantOut {
-		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, wantOut)
-	}
+	assert.Equal(t, wantOut, out)
 }
 
 func TestDateFieldOrder(t *testing.T) {
@@ -401,9 +374,7 @@ func TestDateFieldOrder(t *testing.T) {
 	}
 	got := string(mustFormatNote(t, fm, []byte("body\n")))
 	want := "---\ntitle: T\nslug: s\ntype: meeting\ndate: 2026-04-22\ntags:\n    - a\ndescription: D\npublic: true\n---\n\nbody\n"
-	if got != want {
-		t.Errorf("FormatNote =\n%q\nwant:\n%q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 // Migration check: a note whose `date:` previously landed in Extra (because
@@ -429,9 +400,7 @@ func TestDateMigratesFromExtra(t *testing.T) {
 func TestDateInvalidRejected(t *testing.T) {
 	in := []byte("---\ntitle: T\ndate: not-a-date\n---\n\nbody\n")
 	_, _, err := ParseNote(in)
-	if err == nil {
-		t.Fatal("expected error for malformed date")
-	}
+	require.Error(t, err)
 }
 
 func TestAliasesRoundTrip(t *testing.T) {
@@ -448,9 +417,7 @@ func TestAliasesRoundTrip(t *testing.T) {
 	}
 	out := string(mustFormatNote(t, fm, body))
 	want := "---\ntitle: T\naliases:\n    - old-slug\n    - even-older\n---\n\nbody\n"
-	if out != want {
-		t.Errorf("FormatNote =\n%q\nwant:\n%q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestAliasesFieldOrder(t *testing.T) {
@@ -463,9 +430,7 @@ func TestAliasesFieldOrder(t *testing.T) {
 	}
 	got := string(mustFormatNote(t, fm, []byte("body\n")))
 	want := "---\ntitle: T\nslug: s\ntype: meeting\ndate: 2026-04-22\ntags:\n    - a\naliases:\n    - old\ndescription: D\npublic: true\n---\n\nbody\n"
-	if got != want {
-		t.Errorf("FormatNote =\n%q\nwant:\n%q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 // Migration check: a note whose `aliases:` previously landed in Extra now
@@ -478,9 +443,7 @@ func TestAliasesMigratesFromExtra(t *testing.T) {
 		t.Fatalf("ParseNote: %v", err)
 	}
 	want := []string{"prior-slug", "legacy-id"}
-	if !reflect.DeepEqual(fm.Aliases, want) {
-		t.Errorf("Aliases = %v, want %v", fm.Aliases, want)
-	}
+	assert.Equal(t, want, fm.Aliases)
 	if _, ok := fm.Extra["aliases"]; ok {
 		t.Error("aliases key should not be in Extra after migration")
 	}
@@ -492,9 +455,7 @@ func TestAliasesMigratesFromExtra(t *testing.T) {
 func TestAliasesInvalidRejected(t *testing.T) {
 	in := []byte("---\ntitle: T\naliases: not-a-list\n---\n\nbody\n")
 	_, _, err := ParseNote(in)
-	if err == nil {
-		t.Fatal("expected error for non-list aliases")
-	}
+	require.Error(t, err)
 }
 
 func TestRoundtripWithAliases(t *testing.T) {
@@ -511,9 +472,7 @@ func TestRoundtripWithAliases(t *testing.T) {
 			if err != nil {
 				t.Fatalf("parse failed: %v", err)
 			}
-			if !reflect.DeepEqual(gotF.Aliases, fm.Aliases) {
-				t.Errorf("Aliases: got %v, want %v", gotF.Aliases, fm.Aliases)
-			}
+			assert.Equal(t, fm.Aliases, gotF.Aliases)
 			if string(gotBody) != "body\n" {
 				t.Errorf("body: got %q, want %q", string(gotBody), "body\n")
 			}

--- a/note/id_test.go
+++ b/note/id_test.go
@@ -6,6 +6,9 @@ import (
 	"sort"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadID(t *testing.T) {
@@ -15,9 +18,7 @@ func TestReadID(t *testing.T) {
 	}
 
 	idf, err := readID(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	if idf.LastID != 9218 {
 		t.Errorf("got LastID=%d, want 9218", idf.LastID)
 	}
@@ -26,9 +27,7 @@ func TestReadID(t *testing.T) {
 func TestReadIDMissing(t *testing.T) {
 	dir := t.TempDir()
 	_, err := readID(dir)
-	if err == nil {
-		t.Fatal("expected error for missing id.json")
-	}
+	require.Error(t, err)
 }
 
 func TestReadIDInvalid(t *testing.T) {
@@ -38,9 +37,7 @@ func TestReadIDInvalid(t *testing.T) {
 	}
 
 	_, err := readID(dir)
-	if err == nil {
-		t.Fatal("expected error for invalid JSON")
-	}
+	require.Error(t, err)
 }
 
 func TestNextID(t *testing.T) {
@@ -50,12 +47,8 @@ func TestNextID(t *testing.T) {
 	}
 
 	id, err := NextID(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if id != 9219 {
-		t.Errorf("got id=%d, want 9219", id)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, 9219, id)
 
 	// Verify file was updated
 	idf, err := readID(dir)
@@ -76,12 +69,8 @@ func TestNextIDConsecutive(t *testing.T) {
 	id1, _ := NextID(dir)
 	id2, _ := NextID(dir)
 
-	if id1 != 101 {
-		t.Errorf("first call: got %d, want 101", id1)
-	}
-	if id2 != 102 {
-		t.Errorf("second call: got %d, want 102", id2)
-	}
+	assert.Equal(t, 101, id1)
+	assert.Equal(t, 102, id2)
 }
 
 func TestNextIDConcurrent(t *testing.T) {
@@ -130,9 +119,7 @@ func TestWriteIDAtomic(t *testing.T) {
 	}
 
 	err := writeID(dir, idFile{LastID: 42})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// No temp files should remain
 	entries, _ := os.ReadDir(dir)

--- a/note/mem_store_test.go
+++ b/note/mem_store_test.go
@@ -5,17 +5,16 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemStore_IDsEmpty(t *testing.T) {
 	s := NewMemStore()
 	ids, err := s.IDs()
-	if err != nil {
-		t.Fatalf("IDs: %v", err)
-	}
-	if len(ids) != 0 {
-		t.Fatalf("IDs on empty store = %v, want empty", ids)
-	}
+	require.NoError(t, err)
+	assert.Empty(t, ids)
 }
 
 func TestMemStore_IDsOrderNewestFirstThenIDDesc(t *testing.T) {
@@ -28,9 +27,7 @@ func TestMemStore_IDsOrderNewestFirstThenIDDesc(t *testing.T) {
 	mustPut(t, s, Entry{ID: 3, Meta: Meta{CreatedAt: day2}})
 
 	ids, err := s.IDs()
-	if err != nil {
-		t.Fatalf("IDs: %v", err)
-	}
+	require.NoError(t, err)
 	want := []int{3, 2, 1}
 	if !sliceEqual(ids, want) {
 		t.Fatalf("IDs = %v, want %v", ids, want)
@@ -43,9 +40,7 @@ func TestMemStore_AllNoOpts(t *testing.T) {
 		mustPut(t, s, Entry{ID: i, Meta: Meta{CreatedAt: time.Date(2026, 1, i, 0, 0, 0, 0, time.UTC)}})
 	}
 	entries, err := s.All()
-	if err != nil {
-		t.Fatalf("All: %v", err)
-	}
+	require.NoError(t, err)
 	if len(entries) != 3 {
 		t.Fatalf("All len = %d, want 3", len(entries))
 	}
@@ -61,9 +56,7 @@ func TestMemStore_AllFilterByType(t *testing.T) {
 	mustPut(t, s, Entry{ID: 3, Meta: Meta{Type: "todo", CreatedAt: day(2026, 1, 3)}})
 
 	got, err := s.All(WithType("todo"))
-	if err != nil {
-		t.Fatalf("All: %v", err)
-	}
+	require.NoError(t, err)
 	if len(got) != 2 || got[0].ID != 3 || got[1].ID != 1 {
 		t.Fatalf("All WithType(todo) = %v, want [3 1]", entryIDs(got))
 	}
@@ -76,9 +69,7 @@ func TestMemStore_AllMultipleTagsAreAND(t *testing.T) {
 	mustPut(t, s, Entry{ID: 3, Meta: Meta{Tags: []string{"a", "b", "c"}, CreatedAt: day(2026, 1, 3)}})
 
 	got, err := s.All(WithTag("a"), WithTag("b"))
-	if err != nil {
-		t.Fatalf("All: %v", err)
-	}
+	require.NoError(t, err)
 	if len(got) != 2 || got[0].ID != 3 || got[1].ID != 2 {
 		t.Fatalf("All WithTag(a)+WithTag(b) = %v, want [3 2]", entryIDs(got))
 	}
@@ -88,9 +79,7 @@ func TestMemStore_TagMatchCaseInsensitive(t *testing.T) {
 	s := NewMemStore()
 	mustPut(t, s, Entry{ID: 1, Meta: Meta{Tags: []string{"Alpha"}, CreatedAt: day(2026, 1, 1)}})
 	got, err := s.All(WithTag("alpha"))
-	if err != nil {
-		t.Fatalf("All: %v", err)
-	}
+	require.NoError(t, err)
 	if len(got) != 1 {
 		t.Fatalf("All WithTag(alpha) len = %d, want 1", len(got))
 	}
@@ -101,15 +90,9 @@ func TestMemStore_AllNoMatchEmptySliceNotError(t *testing.T) {
 	mustPut(t, s, Entry{ID: 1, Meta: Meta{Type: "note", CreatedAt: day(2026, 1, 1)}})
 
 	got, err := s.All(WithType("todo"))
-	if err != nil {
-		t.Fatalf("All unexpected err: %v", err)
-	}
-	if len(got) != 0 {
-		t.Fatalf("All no-match len = %d, want 0", len(got))
-	}
-	if errors.Is(err, ErrNotFound) {
-		t.Fatalf("All no-match should not wrap ErrNotFound")
-	}
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.NotErrorIs(t, err, ErrNotFound)
 }
 
 func TestMemStore_AllFilterByExactDate(t *testing.T) {
@@ -119,9 +102,7 @@ func TestMemStore_AllFilterByExactDate(t *testing.T) {
 	mustPut(t, s, Entry{ID: 3, Meta: Meta{CreatedAt: day(2026, 1, 2)}})
 
 	got, err := s.All(WithExactDate(day(2026, 1, 1)))
-	if err != nil {
-		t.Fatalf("All: %v", err)
-	}
+	require.NoError(t, err)
 	if len(got) != 2 {
 		t.Fatalf("All WithExactDate len = %d, want 2", len(got))
 	}
@@ -134,9 +115,7 @@ func TestMemStore_AllFilterByBeforeDate(t *testing.T) {
 	mustPut(t, s, Entry{ID: 3, Meta: Meta{CreatedAt: day(2026, 1, 3)}})
 
 	got, err := s.All(WithBeforeDate(day(2026, 1, 3)))
-	if err != nil {
-		t.Fatalf("All: %v", err)
-	}
+	require.NoError(t, err)
 	if len(got) != 2 || got[0].ID != 2 || got[1].ID != 1 {
 		t.Fatalf("All WithBeforeDate = %v, want [2 1]", entryIDs(got))
 	}
@@ -148,9 +127,7 @@ func TestMemStore_FindReturnsNewest(t *testing.T) {
 	mustPut(t, s, Entry{ID: 2, Meta: Meta{Type: "todo", CreatedAt: day(2026, 1, 2)}})
 
 	got, err := s.Find(WithType("todo"))
-	if err != nil {
-		t.Fatalf("Find: %v", err)
-	}
+	require.NoError(t, err)
 	if got.ID != 2 {
 		t.Fatalf("Find ID = %d, want 2", got.ID)
 	}
@@ -159,9 +136,7 @@ func TestMemStore_FindReturnsNewest(t *testing.T) {
 func TestMemStore_FindNoMatchErrNotFound(t *testing.T) {
 	s := NewMemStore()
 	_, err := s.Find(WithType("todo"))
-	if !errors.Is(err, ErrNotFound) {
-		t.Fatalf("Find no-match err = %v, want ErrNotFound", err)
-	}
+	assert.ErrorIs(t, err, ErrNotFound)
 }
 
 func TestMemStore_Get(t *testing.T) {
@@ -169,25 +144,19 @@ func TestMemStore_Get(t *testing.T) {
 	mustPut(t, s, Entry{ID: 1, Meta: Meta{Title: "one", CreatedAt: day(2026, 1, 1)}})
 
 	got, err := s.Get(1)
-	if err != nil {
-		t.Fatalf("Get hit: %v", err)
-	}
+	require.NoError(t, err)
 	if got.Meta.Title != "one" {
 		t.Fatalf("Get title = %q, want one", got.Meta.Title)
 	}
 
 	_, err = s.Get(99)
-	if !errors.Is(err, ErrNotFound) {
-		t.Fatalf("Get miss err = %v, want ErrNotFound", err)
-	}
+	assert.ErrorIs(t, err, ErrNotFound)
 }
 
 func TestMemStore_PutAssignsIDStartingAt1(t *testing.T) {
 	s := NewMemStore()
 	e, err := s.Put(Entry{Body: "hello"})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 	if e.ID != 1 {
 		t.Fatalf("first Put ID = %d, want 1", e.ID)
 	}
@@ -199,9 +168,7 @@ func TestMemStore_PutAssignsMaxPlusOne(t *testing.T) {
 	mustPut(t, s, Entry{ID: 3, Meta: Meta{CreatedAt: day(2026, 1, 1)}})
 
 	e, err := s.Put(Entry{Body: "new"})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 	if e.ID != 6 {
 		t.Fatalf("Put new ID = %d, want 6", e.ID)
 	}
@@ -213,9 +180,7 @@ func TestMemStore_PutExistingIDReplaces(t *testing.T) {
 	mustPut(t, s, Entry{ID: 1, Meta: Meta{Title: "old", CreatedAt: created}, Body: "old body"})
 
 	e, err := s.Put(Entry{ID: 1, Meta: Meta{Title: "new", CreatedAt: created}, Body: "new body"})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 	if e.Meta.Title != "new" || e.Body != "new body" {
 		t.Fatalf("Put replace = %+v, want title=new body=new body", e)
 	}
@@ -239,9 +204,7 @@ func TestMemStore_PutZeroCreatedAtSetsToNow(t *testing.T) {
 	s := NewMemStore()
 	before := time.Now()
 	e, err := s.Put(Entry{Body: "hi"})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 	after := time.Now()
 
 	if e.Meta.CreatedAt.Before(before) || e.Meta.CreatedAt.After(after) {
@@ -253,9 +216,7 @@ func TestMemStore_PutAlwaysSetsUpdatedAt(t *testing.T) {
 	s := NewMemStore()
 	originalCreated := day(2026, 1, 1)
 	e, err := s.Put(Entry{ID: 1, Meta: Meta{CreatedAt: originalCreated}})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 	if !e.Meta.CreatedAt.Equal(originalCreated) {
 		t.Fatalf("Put changed provided CreatedAt: got %v", e.Meta.CreatedAt)
 	}
@@ -265,9 +226,7 @@ func TestMemStore_PutAlwaysSetsUpdatedAt(t *testing.T) {
 
 	time.Sleep(time.Millisecond)
 	e2, err := s.Put(Entry{ID: 1, Meta: Meta{CreatedAt: originalCreated}})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 	if !e2.Meta.UpdatedAt.After(e.Meta.UpdatedAt) {
 		t.Fatalf("UpdatedAt did not advance: first=%v second=%v", e.Meta.UpdatedAt, e2.Meta.UpdatedAt)
 	}
@@ -321,17 +280,13 @@ func TestMemStore_AllFilterByPublic(t *testing.T) {
 	mustPut(t, s, Entry{ID: 3, Meta: Meta{Public: true, CreatedAt: day(2026, 1, 3)}})
 
 	pub, err := s.All(WithPublic(true))
-	if err != nil {
-		t.Fatalf("All WithPublic(true): %v", err)
-	}
+	require.NoError(t, err)
 	if len(pub) != 2 || pub[0].ID != 3 || pub[1].ID != 1 {
 		t.Fatalf("WithPublic(true) = %v, want [3 1]", entryIDs(pub))
 	}
 
 	priv, err := s.All(WithPublic(false))
-	if err != nil {
-		t.Fatalf("All WithPublic(false): %v", err)
-	}
+	require.NoError(t, err)
 	if len(priv) != 1 || priv[0].ID != 2 {
 		t.Fatalf("WithPublic(false) = %v, want [2]", entryIDs(priv))
 	}
@@ -344,9 +299,7 @@ func TestMemStore_AllPublicComposesWithTag(t *testing.T) {
 	mustPut(t, s, Entry{ID: 3, Meta: Meta{Public: false, Tags: []string{"x"}, CreatedAt: day(2026, 1, 3)}})
 
 	got, err := s.All(WithPublic(true), WithTag("x"))
-	if err != nil {
-		t.Fatalf("All: %v", err)
-	}
+	require.NoError(t, err)
 	if len(got) != 1 || got[0].ID != 1 {
 		t.Fatalf("WithPublic(true)+WithTag(x) = %v, want [1]", entryIDs(got))
 	}
@@ -355,9 +308,7 @@ func TestMemStore_AllPublicComposesWithTag(t *testing.T) {
 func mustPut(t *testing.T, s *MemStore, e Entry) Entry {
 	t.Helper()
 	out, err := s.Put(e)
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 	return out
 }
 

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -2,6 +2,8 @@ package note
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseFilename(t *testing.T) {
@@ -236,7 +238,5 @@ func TestFilename(t *testing.T) {
 func TestDirPath(t *testing.T) {
 	got := DirPath("/archive", "20260312")
 	want := "/archive/2026/03"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }

--- a/note/os_store_test.go
+++ b/note/os_store_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newOSTestStore returns an OSStore rooted at a fresh t.TempDir with an
@@ -28,12 +31,8 @@ func TestOSStore_SatisfiesInterface(t *testing.T) {
 func TestOSStore_IDsEmpty(t *testing.T) {
 	s := newOSTestStore(t)
 	ids, err := s.IDs()
-	if err != nil {
-		t.Fatalf("IDs: %v", err)
-	}
-	if len(ids) != 0 {
-		t.Fatalf("IDs on empty store = %v, want empty", ids)
-	}
+	require.NoError(t, err)
+	assert.Empty(t, ids)
 }
 
 func TestOSStore_IDsOrderIntegerIDNotLexicographic(t *testing.T) {
@@ -44,15 +43,11 @@ func TestOSStore_IDsOrderIntegerIDNotLexicographic(t *testing.T) {
 	// sort 9 before 10/11; the integer-ID sort must put 11 first.
 	for i := 0; i < 11; i++ {
 		_, err := s.Put(Entry{Meta: Meta{Title: "", CreatedAt: today}, Body: "x"})
-		if err != nil {
-			t.Fatalf("Put: %v", err)
-		}
+		require.NoError(t, err)
 	}
 
 	ids, err := s.IDs()
-	if err != nil {
-		t.Fatalf("IDs: %v", err)
-	}
+	require.NoError(t, err)
 	if len(ids) != 11 {
 		t.Fatalf("IDs len = %d, want 11", len(ids))
 	}
@@ -69,9 +64,7 @@ func TestOSStore_PutNewCreatesFile(t *testing.T) {
 		Meta: Meta{Title: "hello", Slug: "hi", CreatedAt: created},
 		Body: "body text\n",
 	})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 	if entry.ID != 1 {
 		t.Fatalf("assigned ID = %d, want 1", entry.ID)
 	}
@@ -90,19 +83,15 @@ func TestOSStore_PutSlugChangeRenames(t *testing.T) {
 	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
 
 	entry, err := s.Put(Entry{Meta: Meta{Slug: "old", CreatedAt: created}, Body: "b"})
-	if err != nil {
-		t.Fatalf("Put new: %v", err)
-	}
+	require.NoError(t, err)
 	oldPath := filepath.Join(s.Root(), "2026", "01", "20260115_1_old.md")
 
 	entry.Meta.Slug = "new"
-	if _, err := s.Put(entry); err != nil {
-		t.Fatalf("Put rename: %v", err)
-	}
+	_, err = s.Put(entry)
+	require.NoError(t, err)
 	newPath := filepath.Join(s.Root(), "2026", "01", "20260115_1_new.md")
-	if _, err := os.Stat(newPath); err != nil {
-		t.Fatalf("new file missing: %v", err)
-	}
+	_, err = os.Stat(newPath)
+	require.NoError(t, err)
 	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
 		t.Fatalf("old file should be gone, got err=%v", err)
 	}
@@ -113,19 +102,15 @@ func TestOSStore_PutDateChangeMovesToNewSubdir(t *testing.T) {
 	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
 
 	entry, err := s.Put(Entry{Meta: Meta{Slug: "x", CreatedAt: created}, Body: "b"})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 	oldPath := filepath.Join(s.Root(), "2026", "01", "20260115_1_x.md")
 
 	entry.Meta.CreatedAt = time.Date(2026, 3, 20, 9, 0, 0, 0, time.UTC)
-	if _, err := s.Put(entry); err != nil {
-		t.Fatalf("Put move: %v", err)
-	}
+	_, err = s.Put(entry)
+	require.NoError(t, err)
 	newPath := filepath.Join(s.Root(), "2026", "03", "20260320_1_x.md")
-	if _, err := os.Stat(newPath); err != nil {
-		t.Fatalf("new path missing: %v", err)
-	}
+	_, err = os.Stat(newPath)
+	require.NoError(t, err)
 	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
 		t.Fatalf("old path should be gone, got err=%v", err)
 	}
@@ -136,14 +121,10 @@ func TestOSStore_Get(t *testing.T) {
 	created := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
 
 	_, err := s.Put(Entry{Meta: Meta{Title: "t", CreatedAt: created}, Body: "body"})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 
 	got, err := s.Get(1)
-	if err != nil {
-		t.Fatalf("Get hit: %v", err)
-	}
+	require.NoError(t, err)
 	if got.Meta.Title != "t" || got.Body != "body" {
 		t.Fatalf("Get = %+v, want title=t body=body", got)
 	}
@@ -158,30 +139,23 @@ func TestOSStore_AllFilterByTagIncludesBodyHashtags(t *testing.T) {
 	created := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
 
 	// entry 1: frontmatter tag alpha
-	if _, err := s.Put(Entry{Meta: Meta{Tags: []string{"alpha"}, CreatedAt: created}, Body: "x"}); err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	_, err := s.Put(Entry{Meta: Meta{Tags: []string{"alpha"}, CreatedAt: created}, Body: "x"})
+	require.NoError(t, err)
 	// entry 2: body-hashtag beta
-	if _, err := s.Put(Entry{Meta: Meta{CreatedAt: created}, Body: "#beta is a body hashtag"}); err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	_, err = s.Put(Entry{Meta: Meta{CreatedAt: created}, Body: "#beta is a body hashtag"})
+	require.NoError(t, err)
 	// entry 3: neither tag
-	if _, err := s.Put(Entry{Meta: Meta{CreatedAt: created}, Body: "nothing"}); err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	_, err = s.Put(Entry{Meta: Meta{CreatedAt: created}, Body: "nothing"})
+	require.NoError(t, err)
 
 	gotAlpha, err := s.All(WithTag("alpha"))
-	if err != nil {
-		t.Fatalf("All alpha: %v", err)
-	}
+	require.NoError(t, err)
 	if len(gotAlpha) != 1 || gotAlpha[0].ID != 1 {
 		t.Fatalf("All alpha = %v, want [1]", entryIDs(gotAlpha))
 	}
 
 	gotBeta, err := s.All(WithTag("beta"))
-	if err != nil {
-		t.Fatalf("All beta: %v", err)
-	}
+	require.NoError(t, err)
 	if len(gotBeta) != 1 || gotBeta[0].ID != 2 {
 		t.Fatalf("All beta = %v, want [2]", entryIDs(gotBeta))
 	}
@@ -192,15 +166,12 @@ func TestOSStore_FindStopsAtFirstMatch(t *testing.T) {
 	// Three todo entries across different days; newest first.
 	for i := 1; i <= 3; i++ {
 		day := time.Date(2026, 1, i, 0, 0, 0, 0, time.UTC)
-		if _, err := s.Put(Entry{Meta: Meta{Type: "todo", CreatedAt: day}, Body: ""}); err != nil {
-			t.Fatalf("Put: %v", err)
-		}
+		_, err := s.Put(Entry{Meta: Meta{Type: "todo", CreatedAt: day}, Body: ""})
+		require.NoError(t, err)
 	}
 
 	got, err := s.Find(WithType("todo"))
-	if err != nil {
-		t.Fatalf("Find: %v", err)
-	}
+	require.NoError(t, err)
 	if got.ID != 3 {
 		t.Fatalf("Find newest todo ID = %d, want 3", got.ID)
 	}
@@ -209,9 +180,7 @@ func TestOSStore_FindStopsAtFirstMatch(t *testing.T) {
 func TestOSStore_FindNoMatch(t *testing.T) {
 	s := newOSTestStore(t)
 	_, err := s.Find(WithType("todo"))
-	if !errors.Is(err, ErrNotFound) {
-		t.Fatalf("Find miss err = %v, want ErrNotFound", err)
-	}
+	assert.ErrorIs(t, err, ErrNotFound)
 }
 
 func TestOSStore_Delete(t *testing.T) {
@@ -219,9 +188,7 @@ func TestOSStore_Delete(t *testing.T) {
 	created := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
 
 	entry, err := s.Put(Entry{Meta: Meta{Slug: "x", CreatedAt: created}, Body: "b"})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 
 	if err := s.Delete(entry.ID); err != nil {
 		t.Fatalf("Delete hit: %v", err)
@@ -246,9 +213,7 @@ func TestOSStore_AbsPathNoIO(t *testing.T) {
 		},
 	}
 	want := filepath.Join(root, "2026", "02", "20260201_42_demo.md")
-	if got := s.AbsPath(entry); got != want {
-		t.Fatalf("AbsPath = %s, want %s", got, want)
-	}
+	assert.Equal(t, want, s.AbsPath(entry))
 	// no file should have been created as a side effect
 	if _, err := os.Stat(want); !os.IsNotExist(err) {
 		t.Fatalf("AbsPath created a file: err=%v", err)
@@ -271,14 +236,10 @@ func TestOSStore_RoundTripPreservesFrontmatterAndTags(t *testing.T) {
 		},
 		Body: "body with #gamma\n",
 	})
-	if err != nil {
-		t.Fatalf("Put: %v", err)
-	}
+	require.NoError(t, err)
 
 	got, err := s.Get(entry.ID)
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
+	require.NoError(t, err)
 
 	if got.Meta.Title != "Test" || got.Meta.Slug != "test" || got.Meta.Type != "note" {
 		t.Fatalf("round-trip meta = %+v", got.Meta)
@@ -291,9 +252,7 @@ func TestOSStore_RoundTripPreservesFrontmatterAndTags(t *testing.T) {
 	for _, tag := range got.Meta.Tags {
 		delete(want, tag)
 	}
-	if len(want) != 0 {
-		t.Fatalf("round-trip Tags missing: %v (got %v)", want, got.Meta.Tags)
-	}
+	assert.Empty(t, want)
 }
 
 func TestOSStore_AllFilterByPublic(t *testing.T) {
@@ -301,22 +260,14 @@ func TestOSStore_AllFilterByPublic(t *testing.T) {
 
 	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
 	_, err := s.Put(Entry{Meta: Meta{Title: "pub", Public: true, CreatedAt: base}, Body: "p\n"})
-	if err != nil {
-		t.Fatalf("Put pub: %v", err)
-	}
+	require.NoError(t, err)
 	_, err = s.Put(Entry{Meta: Meta{Title: "priv-explicit", Public: false, CreatedAt: base.Add(24 * time.Hour)}, Body: "x\n"})
-	if err != nil {
-		t.Fatalf("Put priv-explicit: %v", err)
-	}
+	require.NoError(t, err)
 	_, err = s.Put(Entry{Meta: Meta{Title: "pub2", Public: true, CreatedAt: base.Add(48 * time.Hour)}, Body: "y\n"})
-	if err != nil {
-		t.Fatalf("Put pub2: %v", err)
-	}
+	require.NoError(t, err)
 
 	pub, err := s.All(WithPublic(true))
-	if err != nil {
-		t.Fatalf("All WithPublic(true): %v", err)
-	}
+	require.NoError(t, err)
 	if len(pub) != 2 {
 		t.Fatalf("WithPublic(true) len = %d, want 2 (got IDs %v)", len(pub), entryIDs(pub))
 	}
@@ -327,9 +278,7 @@ func TestOSStore_AllFilterByPublic(t *testing.T) {
 	}
 
 	priv, err := s.All(WithPublic(false))
-	if err != nil {
-		t.Fatalf("All WithPublic(false): %v", err)
-	}
+	require.NoError(t, err)
 	if len(priv) != 1 {
 		t.Fatalf("WithPublic(false) len = %d, want 1 (got IDs %v)", len(priv), entryIDs(priv))
 	}

--- a/note/query_test.go
+++ b/note/query_test.go
@@ -1,6 +1,10 @@
 package note
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestMatches_WithPublic(t *testing.T) {
 	pub := Entry{ID: 1, Meta: Meta{Public: true}}
@@ -20,9 +24,7 @@ func TestMatches_WithPublic(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			q := buildQuery([]QueryOpt{tc.opt})
-			if got := matches(tc.entry, q); got != tc.want {
-				t.Fatalf("matches = %v, want %v", got, tc.want)
-			}
+			assert.Equal(t, tc.want, matches(tc.entry, q))
 		})
 	}
 }
@@ -33,9 +35,7 @@ func TestMatches_WithPublicNotSetMatchesAny(t *testing.T) {
 		{Meta: Meta{Public: true}},
 		{Meta: Meta{Public: false}},
 	} {
-		if !matches(e, q) {
-			t.Fatalf("matches with no opts should accept %+v", e)
-		}
+		assert.True(t, matches(e, q))
 	}
 }
 
@@ -50,9 +50,7 @@ func TestMatches_WithPublicAndTagAreAND(t *testing.T) {
 		{Entry{Meta: Meta{Public: true, Tags: []string{"y"}}}, false},
 		{Entry{Meta: Meta{Public: false, Tags: []string{"x"}}}, false},
 	}
-	for i, c := range cases {
-		if got := matches(c.entry, q); got != c.want {
-			t.Fatalf("case %d: matches = %v, want %v", i, got, c.want)
-		}
+	for _, c := range cases {
+		assert.Equal(t, c.want, matches(c.entry, q))
 	}
 }

--- a/note/tags_test.go
+++ b/note/tags_test.go
@@ -1,8 +1,9 @@
 package note
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtractHashtagsBasic(t *testing.T) {
@@ -22,9 +23,7 @@ func TestExtractHashtagsBasic(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got := ExtractHashtags([]byte(c.in))
-			if !reflect.DeepEqual(got, c.want) {
-				t.Fatalf("got %v, want %v", got, c.want)
-			}
+			assert.Equal(t, c.want, got)
 		})
 	}
 }
@@ -50,9 +49,7 @@ func TestExtractHashtagsNegative(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got := ExtractHashtags([]byte(c.in))
-			if len(got) != 0 {
-				t.Fatalf("expected no tags, got %v", got)
-			}
+			assert.Empty(t, got)
 		})
 	}
 }
@@ -61,44 +58,34 @@ func TestExtractHashtagsInlineCode(t *testing.T) {
 	in := "real #out and `inline #in` and #back"
 	want := []string{"out", "back"}
 	got := ExtractHashtags([]byte(in))
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestExtractHashtagsFencedBlock(t *testing.T) {
 	in := "before #a\n```\n#hidden\n#also-hidden\n```\nafter #b\n"
 	want := []string{"a", "b"}
 	got := ExtractHashtags([]byte(in))
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestExtractHashtagsFencedBlockWithInfoString(t *testing.T) {
 	in := "top #ok\n```go\n// #comment\n```\nend #done\n"
 	want := []string{"ok", "done"}
 	got := ExtractHashtags([]byte(in))
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestExtractHashtagsCRLF(t *testing.T) {
 	in := "before #a\r\n```\r\n#hidden\r\n```\r\nafter #b\r\n"
 	want := []string{"a", "b"}
 	got := ExtractHashtags([]byte(in))
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestExtractHashtagsBareHash(t *testing.T) {
 	cases := []string{"#", "text # and #", "line #\nnext #"}
 	for _, in := range cases {
 		got := ExtractHashtags([]byte(in))
-		if len(got) != 0 {
-			t.Errorf("input %q: expected no tags, got %v", in, got)
-		}
+		assert.Empty(t, got)
 	}
 }

--- a/note/todo_test.go
+++ b/note/todo_test.go
@@ -3,6 +3,9 @@ package note
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseTask(t *testing.T) {
@@ -33,23 +36,13 @@ func TestParseTask(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			task := ParseTask(tt.line, 0)
 			if tt.wantNil {
-				if task != nil {
-					t.Errorf("expected nil for %q, got %+v", tt.line, task)
-				}
+				assert.Nil(t, task)
 				return
 			}
-			if task == nil {
-				t.Fatalf("expected non-nil for %q", tt.line)
-			}
-			if task.Done != tt.done {
-				t.Errorf("done: got %v, want %v", task.Done, tt.done)
-			}
-			if task.IsDaily != tt.isDaily {
-				t.Errorf("isDaily: got %v, want %v", task.IsDaily, tt.isDaily)
-			}
-			if task.IsMoved != tt.isMoved {
-				t.Errorf("isMoved: got %v, want %v", task.IsMoved, tt.isMoved)
-			}
+			require.NotNil(t, task)
+			assert.Equal(t, tt.done, task.Done)
+			assert.Equal(t, tt.isDaily, task.IsDaily)
+			assert.Equal(t, tt.isMoved, task.IsMoved)
 		})
 	}
 }
@@ -82,9 +75,7 @@ func TestReassembled(t *testing.T) {
 	}
 	got := task.Reassembled("x")
 	want := "  - [x] Some task"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestWithTag(t *testing.T) {
@@ -169,15 +160,11 @@ func TestRolloverTasksMovedFormat(t *testing.T) {
 	for _, line := range result.UpdatedLines {
 		if strings.Contains(line, "Buy milk") && strings.Contains(line, "(moved)") {
 			want := "- [ ] (moved) Buy milk"
-			if line != want {
-				t.Errorf("got %q, want %q", line, want)
-			}
+			assert.Equal(t, want, line)
 		}
 		if strings.Contains(line, "Secret task") && strings.Contains(line, "(moved)") {
 			want := "- [ ] (moved) (private) Secret task"
-			if line != want {
-				t.Errorf("got %q, want %q", line, want)
-			}
+			assert.Equal(t, want, line)
 		}
 	}
 }
@@ -194,9 +181,7 @@ func TestRolloverTasksSkipsMoved(t *testing.T) {
 	if len(result.CarriedTasks) != 1 {
 		t.Fatalf("carried %d tasks, want 1", len(result.CarriedTasks))
 	}
-	if !strings.Contains(result.CarriedTasks[0].Text, "Fresh task") {
-		t.Errorf("expected Fresh task, got: %s", result.CarriedTasks[0].Text)
-	}
+	assert.Contains(t, result.CarriedTasks[0].Text, "Fresh task")
 
 	// Already-moved task should not be re-tagged
 	for _, line := range result.UpdatedLines {
@@ -265,9 +250,7 @@ func TestFormatTodoContent(t *testing.T) {
 		t.Error("expected Task two with reset marker")
 	}
 	// Tasks separated by blank lines
-	if !strings.Contains(content, "- [ ] Task one\n\n- [ ] Task two") {
-		t.Errorf("tasks should be separated by blank lines, got:\n%s", content)
-	}
+	assert.Contains(t, content, "- [ ] Task one\n\n- [ ] Task two")
 }
 
 func TestFormatTodoContentEmpty(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add Testify as a direct test dependency.
- Replace hand-written test assertions with Testify `assert` / `require` helpers.
- Reduce test boilerplate without removing test coverage.

## References

- <!-- closes | relates to | depends on | blocked by --> #
