### PR TITLE
Optimize test suite structure

### DIFF
--- a/.pi/prompts/review.md
+++ b/.pi/prompts/review.md
@@ -1,0 +1,14 @@
+---
+description: Review current branch against origin/main
+argument-hint: "[focus]"
+---
+Review the current branch against `origin/main`.
+
+Focus on:
+- Correctness and regressions
+- Maintainability and readability
+- Test coverage and whether existing coverage is preserved
+- Whether the changes stay easy to modify and comprehend
+- $ARGUMENTS
+
+Do not make changes. Return concise findings with file/line references where applicable. If there are no findings, say so explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.23] - 2026-04-25
+
+### Changed
+
+- Further simplify the test suite by consolidating repetitive `notes ls` filter cases and adding small store-test assertion helpers ([#256]).
+
 ## [0.3.22] - 2026-04-25
 
 ### Changed
@@ -1061,3 +1067,4 @@ No implementations and no behaviour changes — this PR only establishes the con
 [#168]: https://github.com/dreikanter/notesctl/pull/168
 [#254]: https://github.com/dreikanter/notesctl/pull/254
 [#255]: https://github.com/dreikanter/notesctl/pull/255
+[#256]: https://github.com/dreikanter/notesctl/pull/256

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,4 @@ a follow-up commit on the same branch:
 ## Pull Requests
 
 Use `.github/pull_request_template.md` for all PR bodies. When running `gh pr create`, pass its content via `--body`.
+Drop the `References` section from the PR description when it would only contain the empty placeholder.

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,148 +29,52 @@ func TestLsNoArgs(t *testing.T) {
 	out, err := runLs(t)
 	require.NoError(t, err)
 
-	lines := strings.Split(out, "\n")
-	if len(lines) != 4 {
-		t.Fatalf("got %d lines, want 4:\n%s", len(lines), out)
-	}
+	lines := outputLines(out)
+	assert.Len(t, lines, 4)
 	for _, line := range lines {
-		if !allDigits(line) {
-			t.Fatalf("expected integer ID per line, got %q", line)
-		}
+		assert.True(t, allDigits(line), "expected integer ID per line, got %q", line)
 	}
 }
 
-func TestLsWithTag(t *testing.T) {
-	out, err := runLs(t, "--tag", "work")
-	require.NoError(t, err)
+func TestLsFilters(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantCount int
+		wantIDs   []string
+	}{
+		{name: "tag", args: []string{"--tag", "work"}, wantCount: 3},
+		{name: "tag mixed case", args: []string{"--tag", "WORK"}, wantCount: 3},
+		{name: "tag no match", args: []string{"--tag", "nonexistent"}},
+		{name: "tag and type", args: []string{"--tag", "work", "--type", "todo"}, wantIDs: []string{"8814"}},
+		{name: "tag and limit", args: []string{"--tag", "work", "--limit", "1"}, wantCount: 1},
+		{name: "multiple tags are AND", args: []string{"--tag", "work", "--tag", "planning"}, wantIDs: []string{"8814"}},
+		{name: "comma-separated tags are AND", args: []string{"--tag", "work,meeting"}, wantIDs: []string{"8818"}},
+		{name: "tag and type no overlap", args: []string{"--tag", "meeting", "--type", "todo"}},
+		{name: "today excludes past testdata", args: []string{"--today"}},
+		{name: "slug", args: []string{"--slug", "meeting"}, wantIDs: []string{"8818"}},
+	}
 
-	lines := strings.Split(out, "\n")
-	if len(lines) != 3 {
-		t.Fatalf("got %d lines, want 3:\n%s", len(lines), out)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := runLs(t, tt.args...)
+			require.NoError(t, err)
+
+			lines := outputLines(out)
+			if tt.wantIDs != nil {
+				assert.Equal(t, tt.wantIDs, lines)
+				return
+			}
+			assert.Len(t, lines, tt.wantCount)
+		})
 	}
 }
 
-func TestLsWithTagMixedCase(t *testing.T) {
-	out, err := runLs(t, "--tag", "WORK")
-	require.NoError(t, err)
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 3 {
-		t.Fatalf("got %d lines, want 3:\n%s", len(lines), out)
+func outputLines(out string) []string {
+	if out == "" {
+		return nil
 	}
-}
-
-func TestLsTagNoMatch(t *testing.T) {
-	out, err := runLs(t, "--tag", "nonexistent")
-	require.NoError(t, err)
-
-	if out != "" {
-		t.Errorf("expected empty output, got %q", out)
-	}
-}
-
-func TestLsTagAndType(t *testing.T) {
-	out, err := runLs(t, "--tag", "work", "--type", "todo")
-	require.NoError(t, err)
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 1 {
-		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
-	}
-	if lines[0] != "8814" {
-		t.Errorf("expected ID 8814, got %q", lines[0])
-	}
-}
-
-func TestLsTagAndLimit(t *testing.T) {
-	out, err := runLs(t, "--tag", "work", "--limit", "1")
-	require.NoError(t, err)
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 1 {
-		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
-	}
-}
-
-func TestLsMultipleTagsAND(t *testing.T) {
-	out, err := runLs(t, "--tag", "work", "--tag", "planning")
-	require.NoError(t, err)
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 1 {
-		t.Fatalf("got %d lines, want 1 (only todo has both work+planning):\n%s", len(lines), out)
-	}
-	if lines[0] != "8814" {
-		t.Errorf("expected ID 8814, got %q", lines[0])
-	}
-}
-
-func TestLsMultipleTagsCommaSeparated(t *testing.T) {
-	out, err := runLs(t, "--tag", "work,meeting")
-	require.NoError(t, err)
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 1 {
-		t.Fatalf("got %d lines, want 1 (only meeting note has both work+meeting):\n%s", len(lines), out)
-	}
-	if lines[0] != "8818" {
-		t.Errorf("expected ID 8818, got %q", lines[0])
-	}
-}
-
-func TestLsTagAndTypeNoOverlap(t *testing.T) {
-	out, err := runLs(t, "--tag", "meeting", "--type", "todo")
-	require.NoError(t, err)
-
-	if out != "" {
-		t.Errorf("expected empty output (no todo with meeting tag), got %q", out)
-	}
-}
-
-func TestLsToday(t *testing.T) {
-	// testdata notes are all in the past; --today should return nothing
-	out, err := runLs(t, "--today")
-	require.NoError(t, err)
-	if out != "" {
-		t.Errorf("expected empty output for --today on past testdata, got %q", out)
-	}
-}
-
-func TestLsUnlimitedByDefault(t *testing.T) {
-	out, err := runLs(t)
-	require.NoError(t, err)
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 4 {
-		t.Fatalf("expected all 4 testdata notes without limit, got %d:\n%s", len(lines), out)
-	}
-}
-
-func TestLsOutputsIntegerIDs(t *testing.T) {
-	out, err := runLs(t)
-	require.NoError(t, err)
-
-	for _, line := range strings.Split(out, "\n") {
-		if line == "" {
-			continue
-		}
-		if !allDigits(line) {
-			t.Errorf("expected integer ID per line, got %q", line)
-		}
-	}
-}
-
-func TestLsSlug(t *testing.T) {
-	out, err := runLs(t, "--slug", "meeting")
-	require.NoError(t, err)
-
-	lines := strings.Split(out, "\n")
-	if len(lines) != 1 {
-		t.Fatalf("got %d lines, want 1:\n%s", len(lines), out)
-	}
-	if lines[0] != "8818" {
-		t.Errorf("expected ID 8818, got %q", lines[0])
-	}
+	return strings.Split(out, "\n")
 }
 
 func allDigits(s string) bool {

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -45,13 +45,13 @@ func TestLsFilters(t *testing.T) {
 	}{
 		{name: "tag", args: []string{"--tag", "work"}, wantCount: 3},
 		{name: "tag mixed case", args: []string{"--tag", "WORK"}, wantCount: 3},
-		{name: "tag no match", args: []string{"--tag", "nonexistent"}},
+		{name: "tag no match", args: []string{"--tag", "nonexistent"}, wantCount: 0},
 		{name: "tag and type", args: []string{"--tag", "work", "--type", "todo"}, wantIDs: []string{"8814"}},
 		{name: "tag and limit", args: []string{"--tag", "work", "--limit", "1"}, wantCount: 1},
 		{name: "multiple tags are AND", args: []string{"--tag", "work", "--tag", "planning"}, wantIDs: []string{"8814"}},
 		{name: "comma-separated tags are AND", args: []string{"--tag", "work,meeting"}, wantIDs: []string{"8818"}},
-		{name: "tag and type no overlap", args: []string{"--tag", "meeting", "--type", "todo"}},
-		{name: "today excludes past testdata", args: []string{"--today"}},
+		{name: "tag and type no overlap", args: []string{"--tag", "meeting", "--type", "todo"}, wantCount: 0},
+		{name: "today excludes past testdata", args: []string{"--today"}, wantCount: 0},
 		{name: "slug", args: []string{"--slug", "meeting"}, wantIDs: []string{"8818"}},
 	}
 

--- a/internal/cli/tags_test.go
+++ b/internal/cli/tags_test.go
@@ -26,21 +26,15 @@ func runTags(t *testing.T, root string, args ...string) (string, error) {
 func writeTagsTestNote(t *testing.T, root, rel, content string) {
 	t.Helper()
 	full := filepath.Join(root, rel)
-	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0o644))
 }
 
 func TestTagsEmptyStore(t *testing.T) {
 	root := t.TempDir()
 	out, err := runTags(t, root)
 	require.NoError(t, err)
-	if out != "" {
-		t.Fatalf("expected empty output, got %q", out)
-	}
+	assert.Empty(t, out)
 }
 
 func TestTagsMergedSourcesSorted(t *testing.T) {
@@ -52,16 +46,7 @@ func TestTagsMergedSourcesSorted(t *testing.T) {
 
 	out, err := runTags(t, root)
 	require.NoError(t, err)
-	got := strings.Split(out, "\n")
-	want := []string{"coffee", "planning", "tea", "work"}
-	if len(got) != len(want) {
-		t.Fatalf("got %d lines, want %d:\n%s", len(got), len(want), out)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("line %d: got %q, want %q", i, got[i], want[i])
-		}
-	}
+	assert.Equal(t, []string{"coffee", "planning", "tea", "work"}, strings.Split(out, "\n"))
 }
 
 func TestTagsLowercased(t *testing.T) {
@@ -71,16 +56,7 @@ func TestTagsLowercased(t *testing.T) {
 
 	out, err := runTags(t, root)
 	require.NoError(t, err)
-	got := strings.Split(out, "\n")
-	want := []string{"coffee", "planning", "work"}
-	if len(got) != len(want) {
-		t.Fatalf("got %d lines, want %d:\n%s", len(got), len(want), out)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("line %d: got %q, want %q", i, got[i], want[i])
-		}
-	}
+	assert.Equal(t, []string{"coffee", "planning", "work"}, strings.Split(out, "\n"))
 }
 
 func TestTagsIgnoresCodeBlocks(t *testing.T) {
@@ -91,7 +67,6 @@ func TestTagsIgnoresCodeBlocks(t *testing.T) {
 	out, err := runTags(t, root)
 	require.NoError(t, err)
 	assert.NotContains(t, out, "should-not-appear")
-	if !strings.Contains(out, "real") || !strings.Contains(out, "done") {
-		t.Errorf("expected real and done tags, got:\n%s", out)
-	}
+	assert.Contains(t, out, "real")
+	assert.Contains(t, out, "done")
 }

--- a/note/mem_store_test.go
+++ b/note/mem_store_test.go
@@ -1,7 +1,6 @@
 package note
 
 import (
-	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -28,10 +27,7 @@ func TestMemStore_IDsOrderNewestFirstThenIDDesc(t *testing.T) {
 
 	ids, err := s.IDs()
 	require.NoError(t, err)
-	want := []int{3, 2, 1}
-	if !sliceEqual(ids, want) {
-		t.Fatalf("IDs = %v, want %v", ids, want)
-	}
+	assert.Equal(t, []int{3, 2, 1}, ids)
 }
 
 func TestMemStore_AllNoOpts(t *testing.T) {
@@ -41,12 +37,7 @@ func TestMemStore_AllNoOpts(t *testing.T) {
 	}
 	entries, err := s.All()
 	require.NoError(t, err)
-	if len(entries) != 3 {
-		t.Fatalf("All len = %d, want 3", len(entries))
-	}
-	if entries[0].ID != 3 || entries[2].ID != 1 {
-		t.Fatalf("All order = %v, want [3 2 1]", entryIDs(entries))
-	}
+	assertEntryIDs(t, []int{3, 2, 1}, entries)
 }
 
 func TestMemStore_AllFilterByType(t *testing.T) {
@@ -57,9 +48,7 @@ func TestMemStore_AllFilterByType(t *testing.T) {
 
 	got, err := s.All(WithType("todo"))
 	require.NoError(t, err)
-	if len(got) != 2 || got[0].ID != 3 || got[1].ID != 1 {
-		t.Fatalf("All WithType(todo) = %v, want [3 1]", entryIDs(got))
-	}
+	assertEntryIDs(t, []int{3, 1}, got)
 }
 
 func TestMemStore_AllMultipleTagsAreAND(t *testing.T) {
@@ -70,9 +59,7 @@ func TestMemStore_AllMultipleTagsAreAND(t *testing.T) {
 
 	got, err := s.All(WithTag("a"), WithTag("b"))
 	require.NoError(t, err)
-	if len(got) != 2 || got[0].ID != 3 || got[1].ID != 2 {
-		t.Fatalf("All WithTag(a)+WithTag(b) = %v, want [3 2]", entryIDs(got))
-	}
+	assertEntryIDs(t, []int{3, 2}, got)
 }
 
 func TestMemStore_TagMatchCaseInsensitive(t *testing.T) {
@@ -80,9 +67,7 @@ func TestMemStore_TagMatchCaseInsensitive(t *testing.T) {
 	mustPut(t, s, Entry{ID: 1, Meta: Meta{Tags: []string{"Alpha"}, CreatedAt: day(2026, 1, 1)}})
 	got, err := s.All(WithTag("alpha"))
 	require.NoError(t, err)
-	if len(got) != 1 {
-		t.Fatalf("All WithTag(alpha) len = %d, want 1", len(got))
-	}
+	assertEntryIDs(t, []int{1}, got)
 }
 
 func TestMemStore_AllNoMatchEmptySliceNotError(t *testing.T) {
@@ -103,9 +88,7 @@ func TestMemStore_AllFilterByExactDate(t *testing.T) {
 
 	got, err := s.All(WithExactDate(day(2026, 1, 1)))
 	require.NoError(t, err)
-	if len(got) != 2 {
-		t.Fatalf("All WithExactDate len = %d, want 2", len(got))
-	}
+	assertEntryIDs(t, []int{2, 1}, got)
 }
 
 func TestMemStore_AllFilterByBeforeDate(t *testing.T) {
@@ -116,9 +99,7 @@ func TestMemStore_AllFilterByBeforeDate(t *testing.T) {
 
 	got, err := s.All(WithBeforeDate(day(2026, 1, 3)))
 	require.NoError(t, err)
-	if len(got) != 2 || got[0].ID != 2 || got[1].ID != 1 {
-		t.Fatalf("All WithBeforeDate = %v, want [2 1]", entryIDs(got))
-	}
+	assertEntryIDs(t, []int{2, 1}, got)
 }
 
 func TestMemStore_FindReturnsNewest(t *testing.T) {
@@ -128,9 +109,7 @@ func TestMemStore_FindReturnsNewest(t *testing.T) {
 
 	got, err := s.Find(WithType("todo"))
 	require.NoError(t, err)
-	if got.ID != 2 {
-		t.Fatalf("Find ID = %d, want 2", got.ID)
-	}
+	assert.Equal(t, 2, got.ID)
 }
 
 func TestMemStore_FindNoMatchErrNotFound(t *testing.T) {
@@ -145,9 +124,7 @@ func TestMemStore_Get(t *testing.T) {
 
 	got, err := s.Get(1)
 	require.NoError(t, err)
-	if got.Meta.Title != "one" {
-		t.Fatalf("Get title = %q, want one", got.Meta.Title)
-	}
+	assert.Equal(t, "one", got.Meta.Title)
 
 	_, err = s.Get(99)
 	assert.ErrorIs(t, err, ErrNotFound)
@@ -157,9 +134,7 @@ func TestMemStore_PutAssignsIDStartingAt1(t *testing.T) {
 	s := NewMemStore()
 	e, err := s.Put(Entry{Body: "hello"})
 	require.NoError(t, err)
-	if e.ID != 1 {
-		t.Fatalf("first Put ID = %d, want 1", e.ID)
-	}
+	assert.Equal(t, 1, e.ID)
 }
 
 func TestMemStore_PutAssignsMaxPlusOne(t *testing.T) {
@@ -169,9 +144,7 @@ func TestMemStore_PutAssignsMaxPlusOne(t *testing.T) {
 
 	e, err := s.Put(Entry{Body: "new"})
 	require.NoError(t, err)
-	if e.ID != 6 {
-		t.Fatalf("Put new ID = %d, want 6", e.ID)
-	}
+	assert.Equal(t, 6, e.ID)
 }
 
 func TestMemStore_PutExistingIDReplaces(t *testing.T) {
@@ -181,13 +154,11 @@ func TestMemStore_PutExistingIDReplaces(t *testing.T) {
 
 	e, err := s.Put(Entry{ID: 1, Meta: Meta{Title: "new", CreatedAt: created}, Body: "new body"})
 	require.NoError(t, err)
-	if e.Meta.Title != "new" || e.Body != "new body" {
-		t.Fatalf("Put replace = %+v, want title=new body=new body", e)
-	}
-	got, _ := s.Get(1)
-	if got.Meta.Title != "new" {
-		t.Fatalf("Get after replace title = %q, want new", got.Meta.Title)
-	}
+	assert.Equal(t, "new", e.Meta.Title)
+	assert.Equal(t, "new body", e.Body)
+	got, err := s.Get(1)
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.Meta.Title)
 }
 
 func TestMemStore_PutUpdateZeroCreatedAtErrors(t *testing.T) {
@@ -195,9 +166,7 @@ func TestMemStore_PutUpdateZeroCreatedAtErrors(t *testing.T) {
 	mustPut(t, s, Entry{ID: 1, Meta: Meta{CreatedAt: day(2026, 1, 1)}})
 
 	_, err := s.Put(Entry{ID: 1, Meta: Meta{Title: "x"}})
-	if err == nil {
-		t.Fatal("Put update with zero CreatedAt: expected error, got nil")
-	}
+	require.Error(t, err)
 }
 
 func TestMemStore_PutZeroCreatedAtSetsToNow(t *testing.T) {
@@ -207,9 +176,8 @@ func TestMemStore_PutZeroCreatedAtSetsToNow(t *testing.T) {
 	require.NoError(t, err)
 	after := time.Now()
 
-	if e.Meta.CreatedAt.Before(before) || e.Meta.CreatedAt.After(after) {
-		t.Fatalf("CreatedAt = %v, want between %v and %v", e.Meta.CreatedAt, before, after)
-	}
+	assert.False(t, e.Meta.CreatedAt.Before(before))
+	assert.False(t, e.Meta.CreatedAt.After(after))
 }
 
 func TestMemStore_PutAlwaysSetsUpdatedAt(t *testing.T) {
@@ -217,34 +185,23 @@ func TestMemStore_PutAlwaysSetsUpdatedAt(t *testing.T) {
 	originalCreated := day(2026, 1, 1)
 	e, err := s.Put(Entry{ID: 1, Meta: Meta{CreatedAt: originalCreated}})
 	require.NoError(t, err)
-	if !e.Meta.CreatedAt.Equal(originalCreated) {
-		t.Fatalf("Put changed provided CreatedAt: got %v", e.Meta.CreatedAt)
-	}
-	if e.Meta.UpdatedAt.IsZero() {
-		t.Fatalf("Put did not set UpdatedAt")
-	}
+	assert.True(t, e.Meta.CreatedAt.Equal(originalCreated))
+	assert.False(t, e.Meta.UpdatedAt.IsZero())
 
 	time.Sleep(time.Millisecond)
 	e2, err := s.Put(Entry{ID: 1, Meta: Meta{CreatedAt: originalCreated}})
 	require.NoError(t, err)
-	if !e2.Meta.UpdatedAt.After(e.Meta.UpdatedAt) {
-		t.Fatalf("UpdatedAt did not advance: first=%v second=%v", e.Meta.UpdatedAt, e2.Meta.UpdatedAt)
-	}
+	assert.True(t, e2.Meta.UpdatedAt.After(e.Meta.UpdatedAt))
 }
 
 func TestMemStore_Delete(t *testing.T) {
 	s := NewMemStore()
 	mustPut(t, s, Entry{ID: 1, Meta: Meta{CreatedAt: day(2026, 1, 1)}})
 
-	if err := s.Delete(1); err != nil {
-		t.Fatalf("Delete hit: %v", err)
-	}
-	if _, err := s.Get(1); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("Get after Delete = %v, want ErrNotFound", err)
-	}
-	if err := s.Delete(1); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("Delete miss err = %v, want ErrNotFound", err)
-	}
+	require.NoError(t, s.Delete(1))
+	_, err := s.Get(1)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.ErrorIs(t, s.Delete(1), ErrNotFound)
 }
 
 func TestMemStore_ConcurrentReads(t *testing.T) {
@@ -281,15 +238,11 @@ func TestMemStore_AllFilterByPublic(t *testing.T) {
 
 	pub, err := s.All(WithPublic(true))
 	require.NoError(t, err)
-	if len(pub) != 2 || pub[0].ID != 3 || pub[1].ID != 1 {
-		t.Fatalf("WithPublic(true) = %v, want [3 1]", entryIDs(pub))
-	}
+	assertEntryIDs(t, []int{3, 1}, pub)
 
 	priv, err := s.All(WithPublic(false))
 	require.NoError(t, err)
-	if len(priv) != 1 || priv[0].ID != 2 {
-		t.Fatalf("WithPublic(false) = %v, want [2]", entryIDs(priv))
-	}
+	assertEntryIDs(t, []int{2}, priv)
 }
 
 func TestMemStore_AllPublicComposesWithTag(t *testing.T) {
@@ -300,9 +253,7 @@ func TestMemStore_AllPublicComposesWithTag(t *testing.T) {
 
 	got, err := s.All(WithPublic(true), WithTag("x"))
 	require.NoError(t, err)
-	if len(got) != 1 || got[0].ID != 1 {
-		t.Fatalf("WithPublic(true)+WithTag(x) = %v, want [1]", entryIDs(got))
-	}
+	assertEntryIDs(t, []int{1}, got)
 }
 
 func mustPut(t *testing.T, s *MemStore, e Entry) Entry {
@@ -316,22 +267,15 @@ func day(y int, m time.Month, d int) time.Time {
 	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 }
 
+func assertEntryIDs(t *testing.T, want []int, entries []Entry) {
+	t.Helper()
+	assert.Equal(t, want, entryIDs(entries))
+}
+
 func entryIDs(entries []Entry) []int {
 	out := make([]int, len(entries))
 	for i, e := range entries {
 		out[i] = e.ID
 	}
 	return out
-}
-
-func sliceEqual(a, b []int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/note/mem_store_test.go
+++ b/note/mem_store_test.go
@@ -176,8 +176,8 @@ func TestMemStore_PutZeroCreatedAtSetsToNow(t *testing.T) {
 	require.NoError(t, err)
 	after := time.Now()
 
-	assert.False(t, e.Meta.CreatedAt.Before(before))
-	assert.False(t, e.Meta.CreatedAt.After(after))
+	assert.False(t, e.Meta.CreatedAt.Before(before), "CreatedAt=%v before=%v", e.Meta.CreatedAt, before)
+	assert.False(t, e.Meta.CreatedAt.After(after), "CreatedAt=%v after=%v", e.Meta.CreatedAt, after)
 }
 
 func TestMemStore_PutAlwaysSetsUpdatedAt(t *testing.T) {

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseFilename(t *testing.T) {
@@ -140,26 +141,14 @@ func TestParseFilename(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseFilename(tt.input)
 			if tt.wantErr {
-				if err == nil {
-					t.Errorf("ParseFilename(%q) expected error, got nil", tt.input)
-				}
+				require.Error(t, err)
 				return
 			}
-			if err != nil {
-				t.Fatalf("ParseFilename(%q) unexpected error: %v", tt.input, err)
-			}
-			if got.Date != tt.wantDate {
-				t.Errorf("Date = %q, want %q", got.Date, tt.wantDate)
-			}
-			if got.ID != tt.wantID {
-				t.Errorf("ID = %q, want %q", got.ID, tt.wantID)
-			}
-			if got.Slug != tt.wantSlug {
-				t.Errorf("Slug = %q, want %q", got.Slug, tt.wantSlug)
-			}
-			if got.Type != tt.wantType {
-				t.Errorf("Type = %q, want %q", got.Type, tt.wantType)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDate, got.Date)
+			assert.Equal(t, tt.wantID, got.ID)
+			assert.Equal(t, tt.wantSlug, got.Slug)
+			assert.Equal(t, tt.wantType, got.Type)
 		})
 	}
 }
@@ -183,29 +172,17 @@ func TestIsDigits(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {
-			if got := IsDigits(c.in); got != c.want {
-				t.Errorf("IsDigits(%q) = %v, want %v", c.in, got, c.want)
-			}
+			assert.Equal(t, c.want, IsDigits(c.in))
 		})
 	}
 }
 
 func TestHasSpecialBehavior(t *testing.T) {
-	if !HasSpecialBehavior("todo") {
-		t.Error("expected todo to have special behavior")
-	}
-	if !HasSpecialBehavior("backlog") {
-		t.Error("expected backlog to have special behavior")
-	}
-	if !HasSpecialBehavior("weekly") {
-		t.Error("expected weekly to have special behavior")
-	}
-	if HasSpecialBehavior("random") {
-		t.Error("expected random to have no special behavior")
-	}
-	if HasSpecialBehavior("") {
-		t.Error("expected empty string to have no special behavior")
-	}
+	assert.True(t, HasSpecialBehavior("todo"))
+	assert.True(t, HasSpecialBehavior("backlog"))
+	assert.True(t, HasSpecialBehavior("weekly"))
+	assert.False(t, HasSpecialBehavior("random"))
+	assert.False(t, HasSpecialBehavior(""))
 }
 
 func TestFilename(t *testing.T) {
@@ -228,10 +205,7 @@ func TestFilename(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := Filename(tt.date, tt.id, tt.slug, tt.noteType)
-		if got != tt.want {
-			t.Errorf("Filename(%q, %d, %q, %q) = %q, want %q", tt.date, tt.id, tt.slug, tt.noteType, got, tt.want)
-		}
+		assert.Equal(t, tt.want, Filename(tt.date, tt.id, tt.slug, tt.noteType))
 	}
 }
 

--- a/note/os_store_test.go
+++ b/note/os_store_test.go
@@ -240,7 +240,8 @@ func TestOSStore_AllFilterByPublic(t *testing.T) {
 
 	priv, err := s.All(WithPublic(false))
 	require.NoError(t, err)
-	assertEntryIDs(t, []int{2}, priv)
+	require.Len(t, priv, 1)
+	assert.Equal(t, 2, priv[0].ID)
 	assert.False(t, priv[0].Meta.Public)
 }
 

--- a/note/os_store_test.go
+++ b/note/os_store_test.go
@@ -2,7 +2,6 @@ package note
 
 import (
 	"encoding/json"
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,9 +17,7 @@ func newOSTestStore(t *testing.T) *OSStore {
 	t.Helper()
 	dir := t.TempDir()
 	data, _ := json.Marshal(map[string]int{"last_id": 0})
-	if err := os.WriteFile(filepath.Join(dir, "id.json"), data, 0o644); err != nil {
-		t.Fatalf("cannot write id.json: %v", err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "id.json"), data, 0o644))
 	return NewOSStore(dir)
 }
 
@@ -48,12 +45,8 @@ func TestOSStore_IDsOrderIntegerIDNotLexicographic(t *testing.T) {
 
 	ids, err := s.IDs()
 	require.NoError(t, err)
-	if len(ids) != 11 {
-		t.Fatalf("IDs len = %d, want 11", len(ids))
-	}
-	if ids[0] != 11 || ids[1] != 10 || ids[2] != 9 {
-		t.Fatalf("IDs order = %v, want [11 10 9 ...]", ids)
-	}
+	assert.Equal(t, []int{11, 10, 9}, ids[:3])
+	assert.Len(t, ids, 11)
 }
 
 func TestOSStore_PutNewCreatesFile(t *testing.T) {
@@ -65,17 +58,11 @@ func TestOSStore_PutNewCreatesFile(t *testing.T) {
 		Body: "body text\n",
 	})
 	require.NoError(t, err)
-	if entry.ID != 1 {
-		t.Fatalf("assigned ID = %d, want 1", entry.ID)
-	}
-	if entry.Meta.UpdatedAt.IsZero() {
-		t.Fatal("Put did not set UpdatedAt")
-	}
+	assert.Equal(t, 1, entry.ID)
+	assert.False(t, entry.Meta.UpdatedAt.IsZero())
 
 	expected := filepath.Join(s.Root(), "2026", "01", "20260115_1_hi.md")
-	if _, err := os.Stat(expected); err != nil {
-		t.Fatalf("expected file at %s: %v", expected, err)
-	}
+	assertFileExists(t, expected)
 }
 
 func TestOSStore_PutSlugChangeRenames(t *testing.T) {
@@ -90,11 +77,8 @@ func TestOSStore_PutSlugChangeRenames(t *testing.T) {
 	_, err = s.Put(entry)
 	require.NoError(t, err)
 	newPath := filepath.Join(s.Root(), "2026", "01", "20260115_1_new.md")
-	_, err = os.Stat(newPath)
-	require.NoError(t, err)
-	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
-		t.Fatalf("old file should be gone, got err=%v", err)
-	}
+	assertFileExists(t, newPath)
+	assertNoFile(t, oldPath)
 }
 
 func TestOSStore_PutDateChangeMovesToNewSubdir(t *testing.T) {
@@ -109,11 +93,8 @@ func TestOSStore_PutDateChangeMovesToNewSubdir(t *testing.T) {
 	_, err = s.Put(entry)
 	require.NoError(t, err)
 	newPath := filepath.Join(s.Root(), "2026", "03", "20260320_1_x.md")
-	_, err = os.Stat(newPath)
-	require.NoError(t, err)
-	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
-		t.Fatalf("old path should be gone, got err=%v", err)
-	}
+	assertFileExists(t, newPath)
+	assertNoFile(t, oldPath)
 }
 
 func TestOSStore_Get(t *testing.T) {
@@ -125,13 +106,11 @@ func TestOSStore_Get(t *testing.T) {
 
 	got, err := s.Get(1)
 	require.NoError(t, err)
-	if got.Meta.Title != "t" || got.Body != "body" {
-		t.Fatalf("Get = %+v, want title=t body=body", got)
-	}
+	assert.Equal(t, "t", got.Meta.Title)
+	assert.Equal(t, "body", got.Body)
 
-	if _, err := s.Get(99); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("Get miss err = %v, want ErrNotFound", err)
-	}
+	_, err = s.Get(99)
+	assert.ErrorIs(t, err, ErrNotFound)
 }
 
 func TestOSStore_AllFilterByTagIncludesBodyHashtags(t *testing.T) {
@@ -150,15 +129,11 @@ func TestOSStore_AllFilterByTagIncludesBodyHashtags(t *testing.T) {
 
 	gotAlpha, err := s.All(WithTag("alpha"))
 	require.NoError(t, err)
-	if len(gotAlpha) != 1 || gotAlpha[0].ID != 1 {
-		t.Fatalf("All alpha = %v, want [1]", entryIDs(gotAlpha))
-	}
+	assertEntryIDs(t, []int{1}, gotAlpha)
 
 	gotBeta, err := s.All(WithTag("beta"))
 	require.NoError(t, err)
-	if len(gotBeta) != 1 || gotBeta[0].ID != 2 {
-		t.Fatalf("All beta = %v, want [2]", entryIDs(gotBeta))
-	}
+	assertEntryIDs(t, []int{2}, gotBeta)
 }
 
 func TestOSStore_FindStopsAtFirstMatch(t *testing.T) {
@@ -172,9 +147,7 @@ func TestOSStore_FindStopsAtFirstMatch(t *testing.T) {
 
 	got, err := s.Find(WithType("todo"))
 	require.NoError(t, err)
-	if got.ID != 3 {
-		t.Fatalf("Find newest todo ID = %d, want 3", got.ID)
-	}
+	assert.Equal(t, 3, got.ID)
 }
 
 func TestOSStore_FindNoMatch(t *testing.T) {
@@ -190,15 +163,9 @@ func TestOSStore_Delete(t *testing.T) {
 	entry, err := s.Put(Entry{Meta: Meta{Slug: "x", CreatedAt: created}, Body: "b"})
 	require.NoError(t, err)
 
-	if err := s.Delete(entry.ID); err != nil {
-		t.Fatalf("Delete hit: %v", err)
-	}
-	if _, err := os.Stat(s.AbsPath(entry)); !os.IsNotExist(err) {
-		t.Fatalf("file should be gone, got err=%v", err)
-	}
-	if err := s.Delete(entry.ID); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("Delete miss err = %v, want ErrNotFound", err)
-	}
+	require.NoError(t, s.Delete(entry.ID))
+	assertNoFile(t, s.AbsPath(entry))
+	assert.ErrorIs(t, s.Delete(entry.ID), ErrNotFound)
 }
 
 func TestOSStore_AbsPathNoIO(t *testing.T) {
@@ -215,9 +182,7 @@ func TestOSStore_AbsPathNoIO(t *testing.T) {
 	want := filepath.Join(root, "2026", "02", "20260201_42_demo.md")
 	assert.Equal(t, want, s.AbsPath(entry))
 	// no file should have been created as a side effect
-	if _, err := os.Stat(want); !os.IsNotExist(err) {
-		t.Fatalf("AbsPath created a file: err=%v", err)
-	}
+	assertNoFile(t, want)
 }
 
 func TestOSStore_RoundTripPreservesFrontmatterAndTags(t *testing.T) {
@@ -241,18 +206,28 @@ func TestOSStore_RoundTripPreservesFrontmatterAndTags(t *testing.T) {
 	got, err := s.Get(entry.ID)
 	require.NoError(t, err)
 
-	if got.Meta.Title != "Test" || got.Meta.Slug != "test" || got.Meta.Type != "note" {
-		t.Fatalf("round-trip meta = %+v", got.Meta)
-	}
-	if !got.Meta.CreatedAt.Equal(created) {
-		t.Fatalf("round-trip CreatedAt = %v, want %v", got.Meta.CreatedAt, created)
-	}
+	assert.Equal(t, "Test", got.Meta.Title)
+	assert.Equal(t, "test", got.Meta.Slug)
+	assert.Equal(t, "note", got.Meta.Type)
+	assert.True(t, got.Meta.CreatedAt.Equal(created))
 	// Tags should include both frontmatter values and the body hashtag.
 	want := map[string]bool{"alpha": true, "beta": true, "gamma": true}
 	for _, tag := range got.Meta.Tags {
 		delete(want, tag)
 	}
 	assert.Empty(t, want)
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	require.NoError(t, err)
+}
+
+func assertNoFile(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "expected %s not to exist, got err=%v", path, err)
 }
 
 func TestOSStore_AllFilterByPublic(t *testing.T) {
@@ -268,21 +243,13 @@ func TestOSStore_AllFilterByPublic(t *testing.T) {
 
 	pub, err := s.All(WithPublic(true))
 	require.NoError(t, err)
-	if len(pub) != 2 {
-		t.Fatalf("WithPublic(true) len = %d, want 2 (got IDs %v)", len(pub), entryIDs(pub))
-	}
+	assertEntryIDs(t, []int{3, 1}, pub)
 	for _, e := range pub {
-		if !e.Meta.Public {
-			t.Fatalf("WithPublic(true) returned Public=false entry %d", e.ID)
-		}
+		assert.True(t, e.Meta.Public)
 	}
 
 	priv, err := s.All(WithPublic(false))
 	require.NoError(t, err)
-	if len(priv) != 1 {
-		t.Fatalf("WithPublic(false) len = %d, want 1 (got IDs %v)", len(priv), entryIDs(priv))
-	}
-	if priv[0].Meta.Public {
-		t.Fatalf("WithPublic(false) returned Public=true entry %d", priv[0].ID)
-	}
+	assertEntryIDs(t, []int{2}, priv)
+	assert.False(t, priv[0].Meta.Public)
 }

--- a/note/os_store_test.go
+++ b/note/os_store_test.go
@@ -2,6 +2,8 @@ package note
 
 import (
 	"encoding/json"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -251,5 +253,5 @@ func assertFileExists(t *testing.T, path string) {
 func assertNoFile(t *testing.T, path string) {
 	t.Helper()
 	_, err := os.Stat(path)
-	assert.True(t, os.IsNotExist(err), "expected %s not to exist, got err=%v", path, err)
+	assert.True(t, errors.Is(err, fs.ErrNotExist), "expected %s not to exist, got err=%v", path, err)
 }

--- a/note/os_store_test.go
+++ b/note/os_store_test.go
@@ -45,8 +45,8 @@ func TestOSStore_IDsOrderIntegerIDNotLexicographic(t *testing.T) {
 
 	ids, err := s.IDs()
 	require.NoError(t, err)
+	require.Len(t, ids, 11)
 	assert.Equal(t, []int{11, 10, 9}, ids[:3])
-	assert.Len(t, ids, 11)
 }
 
 func TestOSStore_PutNewCreatesFile(t *testing.T) {
@@ -218,18 +218,6 @@ func TestOSStore_RoundTripPreservesFrontmatterAndTags(t *testing.T) {
 	assert.Empty(t, want)
 }
 
-func assertFileExists(t *testing.T, path string) {
-	t.Helper()
-	_, err := os.Stat(path)
-	require.NoError(t, err)
-}
-
-func assertNoFile(t *testing.T, path string) {
-	t.Helper()
-	_, err := os.Stat(path)
-	assert.True(t, os.IsNotExist(err), "expected %s not to exist, got err=%v", path, err)
-}
-
 func TestOSStore_AllFilterByPublic(t *testing.T) {
 	s := newOSTestStore(t)
 
@@ -252,4 +240,16 @@ func TestOSStore_AllFilterByPublic(t *testing.T) {
 	require.NoError(t, err)
 	assertEntryIDs(t, []int{2}, priv)
 	assert.False(t, priv[0].Meta.Public)
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	require.NoError(t, err)
+}
+
+func assertNoFile(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "expected %s not to exist, got err=%v", path, err)
 }


### PR DESCRIPTION
## Summary

- Consolidate repetitive `notes ls` filter tests into a table-driven test.
- Add focused helpers for store test ID and file assertions.
- Replace remaining hand-written utility assertions with Testify helpers.
- Document that empty PR `References` sections should be omitted.
