### PR TITLE
Add OSStore watcher

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,6 @@
 
 -
 
-## References
+## References <!-- Drop this section if no references -->
 
-- <!-- closes | relates to | depends on | blocked by --> #
+- <!-- Closes | Relates to | Depends on | Blocked by --> #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.24] - 2026-04-26
+
+### Added
+
+- `OSStore.Watch(ctx, opts...)` returns a channel-based watcher that emits debounced, per-ID `EventCreated`, `EventUpdated`, and `EventDeleted` notifications for note changes. Watchers are going-forward only; subscribe before `Store.All()` to queue changes during the initial list ([#258]).
+
+[#258]: https://github.com/dreikanter/notesctl/pull/258
+
 ## [0.3.23] - 2026-04-25
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dreikanter/notesctl
 go 1.25.7
 
 require (
+	github.com/fsnotify/fsnotify v1.5.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
 	github.com/stretchr/testify v1.11.1
@@ -53,7 +54,6 @@ require (
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/firefart/nonamedreturns v1.0.5 // indirect
-	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.9 // indirect
 	github.com/go-critic/go-critic v0.12.0 // indirect

--- a/note/watch.go
+++ b/note/watch.go
@@ -1,0 +1,293 @@
+package note
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const (
+	watchDebounce = 100 * time.Millisecond
+	watchBufSize  = 64
+)
+
+// EventType describes the kind of note change a Watcher observed.
+type EventType int
+
+const (
+	EventCreated EventType = iota + 1
+	EventUpdated
+	EventDeleted
+)
+
+// Event is an ID-keyed Store change notification.
+type Event struct {
+	Type EventType
+	ID   int
+}
+
+// Watcher emits Store change events until its context is cancelled or Close is
+// called.
+type Watcher interface {
+	Events() <-chan Event
+	Close() error
+}
+
+// WatchOpt configures OSStore.Watch. No options are currently exposed; the
+// parameter is reserved so options such as WithDebounce can be added without
+// changing the Watch signature.
+type WatchOpt func(*watchConfig)
+
+type watchConfig struct{}
+
+type osWatcher struct {
+	events <-chan Event
+	close  func() error
+}
+
+func (w *osWatcher) Events() <-chan Event { return w.events }
+func (w *osWatcher) Close() error         { return w.close() }
+
+// Watch returns a Watcher that emits ID-keyed events for note files under the
+// store root. Events are going-forward only: Watch does not replay a snapshot.
+// Long-running consumers should subscribe first, then call Store.All, so file
+// changes that happen during the initial list are queued on the watcher.
+//
+// Implementations debounce internally. The current debounce window is fixed at
+// 100 ms and coalesces by ID: create+delete in one window emits nothing, and
+// otherwise the last event in the window wins.
+func (s *OSStore) Watch(ctx context.Context, opts ...WatchOpt) (Watcher, error) {
+	cfg := watchConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := addWatchDirs(fsw, s.root); err != nil {
+		_ = fsw.Close()
+		return nil, err
+	}
+
+	known, err := s.watchKnownIDs()
+	if err != nil {
+		_ = fsw.Close()
+		return nil, err
+	}
+
+	out := make(chan Event, watchBufSize)
+	done := make(chan struct{})
+	var once sync.Once
+	closeFn := func() error {
+		once.Do(func() { close(done) })
+		return nil
+	}
+
+	go s.runWatch(ctx, fsw, known, out, done)
+
+	return &osWatcher{events: out, close: closeFn}, nil
+}
+
+func (s *OSStore) runWatch(
+	ctx context.Context,
+	fsw *fsnotify.Watcher,
+	known map[int]bool,
+	out chan<- Event,
+	done <-chan struct{},
+) {
+	defer close(out)
+	defer fsw.Close()
+
+	pending := make(map[int]Event)
+	var order []int
+	var timer *time.Timer
+	var timerC <-chan time.Time
+
+	stopTimer := func() {
+		if timer == nil {
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer = nil
+		timerC = nil
+	}
+	armTimer := func() {
+		if timer == nil {
+			timer = time.NewTimer(watchDebounce)
+			timerC = timer.C
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(watchDebounce)
+		timerC = timer.C
+	}
+	flush := func() bool {
+		stopTimer()
+		for _, id := range order {
+			e, ok := pending[id]
+			if !ok {
+				continue
+			}
+			select {
+			case out <- e:
+			case <-ctx.Done():
+				return false
+			case <-done:
+				return false
+			}
+		}
+		pending = make(map[int]Event)
+		order = nil
+		return true
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			stopTimer()
+			return
+		case <-done:
+			stopTimer()
+			return
+		case <-timerC:
+			if !flush() {
+				return
+			}
+		case err, ok := <-fsw.Errors:
+			if !ok {
+				stopTimer()
+				return
+			}
+			_ = err
+		case ev, ok := <-fsw.Events:
+			if !ok {
+				stopTimer()
+				return
+			}
+			if ev.Op&fsnotify.Create != 0 {
+				addCreatedDir(fsw, ev.Name)
+			}
+			e, ok := classifyWatchEvent(ev, known)
+			if !ok {
+				continue
+			}
+			order = coalesceWatchEvent(pending, order, e)
+			if len(pending) == 0 {
+				stopTimer()
+			} else {
+				armTimer()
+			}
+		}
+	}
+}
+
+func (s *OSStore) watchKnownIDs() (map[int]bool, error) {
+	refs, err := s.scanFileRefs()
+	if err != nil {
+		return nil, err
+	}
+	known := make(map[int]bool, len(refs))
+	for _, r := range refs {
+		known[r.id] = true
+	}
+	return known, nil
+}
+
+func addWatchDirs(fsw *fsnotify.Watcher, root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return nil
+		}
+		return fsw.Add(path)
+	})
+}
+
+func addCreatedDir(fsw *fsnotify.Watcher, path string) {
+	_ = filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || !d.IsDir() {
+			return nil
+		}
+		_ = fsw.Add(p)
+		return nil
+	})
+}
+
+func classifyWatchEvent(ev fsnotify.Event, known map[int]bool) (Event, bool) {
+	id, ok := watchEventID(ev.Name)
+	if !ok {
+		return Event{}, false
+	}
+
+	if ev.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+		if !known[id] {
+			return Event{}, false
+		}
+		known[id] = false
+		return Event{Type: EventDeleted, ID: id}, true
+	}
+
+	if ev.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Chmod) == 0 {
+		return Event{}, false
+	}
+	if info, err := os.Stat(ev.Name); err != nil || info.IsDir() {
+		return Event{}, false
+	}
+
+	if known[id] {
+		return Event{Type: EventUpdated, ID: id}, true
+	}
+	known[id] = true
+	return Event{Type: EventCreated, ID: id}, true
+}
+
+func watchEventID(path string) (int, bool) {
+	if filepath.Ext(path) != ".md" {
+		return 0, false
+	}
+	base := strings.TrimSuffix(filepath.Base(path), ".md")
+	ref, err := ParseFilename(base)
+	if err != nil {
+		return 0, false
+	}
+	id, err := strconv.Atoi(ref.ID)
+	return id, err == nil
+}
+
+func coalesceWatchEvent(pending map[int]Event, order []int, next Event) []int {
+	prev, ok := pending[next.ID]
+	if !ok {
+		pending[next.ID] = next
+		return append(order, next.ID)
+	}
+
+	if prev.Type == EventCreated && next.Type == EventDeleted {
+		delete(pending, next.ID)
+		return order
+	}
+	if prev.Type == EventDeleted && next.Type == EventCreated {
+		pending[next.ID] = Event{Type: EventUpdated, ID: next.ID}
+		return order
+	}
+	pending[next.ID] = next
+	return order
+}

--- a/note/watch.go
+++ b/note/watch.go
@@ -61,12 +61,18 @@ func (w *osWatcher) Close() error         { return w.close() }
 // changes that happen during the initial list are queued on the watcher.
 //
 // Implementations debounce internally. The current debounce window is fixed at
-// 100 ms and coalesces by ID: create+delete in one window emits nothing, and
-// otherwise the last event in the window wins.
+// 100 ms and coalesces by ID: create+delete in one window emits nothing,
+// create+update emits create, and otherwise the last event in the window wins.
+// Watch performs an initial filename scan before arming filesystem watches.
 func (s *OSStore) Watch(ctx context.Context, opts ...WatchOpt) (Watcher, error) {
 	cfg := watchConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+
+	known, err := s.watchKnownIDs()
+	if err != nil {
+		return nil, err
 	}
 
 	fsw, err := fsnotify.NewWatcher()
@@ -75,12 +81,6 @@ func (s *OSStore) Watch(ctx context.Context, opts ...WatchOpt) (Watcher, error) 
 	}
 
 	if err := addWatchDirs(fsw, s.root); err != nil {
-		_ = fsw.Close()
-		return nil, err
-	}
-
-	known, err := s.watchKnownIDs()
-	if err != nil {
 		_ = fsw.Close()
 		return nil, err
 	}
@@ -178,6 +178,9 @@ func (s *OSStore) runWatch(
 				stopTimer()
 				return
 			}
+			// Watch has no error event in its initial API. Consumers that suspect
+			// drift should recover by re-listing the store; a future WatchOpt can
+			// surface backend errors without changing the Watch signature.
 			_ = err
 		case ev, ok := <-fsw.Events:
 			if !ok {
@@ -269,7 +272,7 @@ func classifyWatchEvent(ev fsnotify.Event, known map[int]bool) (Event, bool) {
 		if !known[id] {
 			return Event{}, false
 		}
-		known[id] = false
+		delete(known, id)
 		return Event{Type: EventDeleted, ID: id}, true
 	}
 

--- a/note/watch.go
+++ b/note/watch.go
@@ -184,11 +184,17 @@ func (s *OSStore) runWatch(
 				stopTimer()
 				return
 			}
-			if ev.Op&fsnotify.Create != 0 {
+			if ev.Op&fsnotify.Create != 0 && watchEventIsDir(ev.Name) {
 				addCreatedDir(fsw, ev.Name)
+				for _, e := range s.discoverWatchCreates(known) {
+					order = coalesceWatchEvent(pending, order, e)
+				}
 			}
 			e, ok := classifyWatchEvent(ev, known)
 			if !ok {
+				if len(pending) > 0 {
+					armTimer()
+				}
 				continue
 			}
 			order = coalesceWatchEvent(pending, order, e)
@@ -222,6 +228,11 @@ func addWatchDirs(fsw *fsnotify.Watcher, root string) error {
 	})
 }
 
+func watchEventIsDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
 func addCreatedDir(fsw *fsnotify.Watcher, path string) {
 	_ = filepath.WalkDir(path, func(p string, d fs.DirEntry, err error) error {
 		if err != nil || !d.IsDir() {
@@ -230,6 +241,22 @@ func addCreatedDir(fsw *fsnotify.Watcher, path string) {
 		_ = fsw.Add(p)
 		return nil
 	})
+}
+
+func (s *OSStore) discoverWatchCreates(known map[int]bool) []Event {
+	refs, err := s.scanFileRefs()
+	if err != nil {
+		return nil
+	}
+	events := make([]Event, 0)
+	for _, r := range refs {
+		if known[r.id] {
+			continue
+		}
+		known[r.id] = true
+		events = append(events, Event{Type: EventCreated, ID: r.id})
+	}
+	return events
 }
 
 func classifyWatchEvent(ev fsnotify.Event, known map[int]bool) (Event, bool) {
@@ -277,9 +304,12 @@ func coalesceWatchEvent(pending map[int]Event, order []int, next Event) []int {
 	prev, ok := pending[next.ID]
 	if !ok {
 		pending[next.ID] = next
-		return append(order, next.ID)
+		return appendWatchOrder(order, next.ID)
 	}
 
+	if prev.Type == EventCreated && next.Type == EventUpdated {
+		return order
+	}
 	if prev.Type == EventCreated && next.Type == EventDeleted {
 		delete(pending, next.ID)
 		return order
@@ -290,4 +320,13 @@ func coalesceWatchEvent(pending map[int]Event, order []int, next Event) []int {
 	}
 	pending[next.ID] = next
 	return order
+}
+
+func appendWatchOrder(order []int, id int) []int {
+	for _, existing := range order {
+		if existing == id {
+			return order
+		}
+	}
+	return append(order, id)
 }

--- a/note/watch_test.go
+++ b/note/watch_test.go
@@ -108,7 +108,7 @@ func TestOSStoreWatchDebouncesSameID(t *testing.T) {
 	require.NoError(t, err)
 
 	assertWatchEvent(t, w, Event{Type: EventUpdated, ID: entry.ID})
-	assertNoWatchEvent(t, w, 150*time.Millisecond)
+	assertNoWatchEvent(t, w, 300*time.Millisecond)
 }
 
 func TestOSStoreWatchCloseWhilePending(t *testing.T) {

--- a/note/watch_test.go
+++ b/note/watch_test.go
@@ -1,0 +1,138 @@
+package note
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatchCoalesceCreateDeleteEmitsNothing(t *testing.T) {
+	pending := make(map[int]Event)
+	var order []int
+
+	order = coalesceWatchEvent(pending, order, Event{Type: EventCreated, ID: 1})
+	order = coalesceWatchEvent(pending, order, Event{Type: EventDeleted, ID: 1})
+
+	assert.Empty(t, pending)
+	assert.Equal(t, []int{1}, order)
+}
+
+func TestWatchCoalesceLastEventWins(t *testing.T) {
+	pending := make(map[int]Event)
+	var order []int
+
+	order = coalesceWatchEvent(pending, order, Event{Type: EventCreated, ID: 1})
+	order = coalesceWatchEvent(pending, order, Event{Type: EventUpdated, ID: 1})
+	order = coalesceWatchEvent(pending, order, Event{Type: EventDeleted, ID: 1})
+
+	assert.Equal(t, Event{Type: EventDeleted, ID: 1}, pending[1])
+	assert.Equal(t, []int{1}, order)
+}
+
+func TestWatchCoalesceDeleteCreateIsUpdate(t *testing.T) {
+	pending := make(map[int]Event)
+	var order []int
+
+	order = coalesceWatchEvent(pending, order, Event{Type: EventDeleted, ID: 1})
+	order = coalesceWatchEvent(pending, order, Event{Type: EventCreated, ID: 1})
+
+	assert.Equal(t, Event{Type: EventUpdated, ID: 1}, pending[1])
+	assert.Equal(t, []int{1}, order)
+}
+
+func TestOSStoreWatchCreatedUpdatedDeleted(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+	watchRoot := filepath.Join(s.Root(), "2026", "01")
+	require.NoError(t, os.MkdirAll(watchRoot, StoreDirMode(s.Root())))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w, err := s.Watch(ctx)
+	require.NoError(t, err)
+	defer w.Close()
+
+	entry, err := s.Put(Entry{Meta: Meta{Slug: "one", CreatedAt: created}, Body: "body"})
+	require.NoError(t, err)
+	assertWatchEvent(t, w, Event{Type: EventCreated, ID: entry.ID})
+
+	entry.Body = "changed"
+	_, err = s.Put(entry)
+	require.NoError(t, err)
+	assertWatchEvent(t, w, Event{Type: EventUpdated, ID: entry.ID})
+
+	require.NoError(t, s.Delete(entry.ID))
+	assertWatchEvent(t, w, Event{Type: EventDeleted, ID: entry.ID})
+}
+
+func TestOSStoreWatchDebouncesSameID(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+	entry, err := s.Put(Entry{Meta: Meta{Slug: "one", CreatedAt: created}, Body: "body"})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w, err := s.Watch(ctx)
+	require.NoError(t, err)
+	defer w.Close()
+
+	entry.Body = "changed once"
+	_, err = s.Put(entry)
+	require.NoError(t, err)
+	entry.Body = "changed twice"
+	_, err = s.Put(entry)
+	require.NoError(t, err)
+
+	assertWatchEvent(t, w, Event{Type: EventUpdated, ID: entry.ID})
+	assertNoWatchEvent(t, w, 150*time.Millisecond)
+}
+
+func TestOSStoreWatchCloseWhilePending(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+	watchRoot := filepath.Join(s.Root(), "2026", "01")
+	require.NoError(t, os.MkdirAll(watchRoot, StoreDirMode(s.Root())))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w, err := s.Watch(ctx)
+	require.NoError(t, err)
+
+	_, err = s.Put(Entry{Meta: Meta{Slug: "one", CreatedAt: created}, Body: "body"})
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	select {
+	case _, ok := <-w.Events():
+		assert.False(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("watcher did not close")
+	}
+}
+
+func assertWatchEvent(t *testing.T, w Watcher, want Event) {
+	t.Helper()
+	select {
+	case got, ok := <-w.Events():
+		require.True(t, ok, "watcher closed before event")
+		assert.Equal(t, want, got)
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for event %#v", want)
+	}
+}
+
+func assertNoWatchEvent(t *testing.T, w Watcher, d time.Duration) {
+	t.Helper()
+	select {
+	case got, ok := <-w.Events():
+		require.True(t, ok, "watcher closed")
+		t.Fatalf("unexpected event %#v", got)
+	case <-time.After(d):
+	}
+}

--- a/note/watch_test.go
+++ b/note/watch_test.go
@@ -2,8 +2,6 @@ package note
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -22,11 +20,21 @@ func TestWatchCoalesceCreateDeleteEmitsNothing(t *testing.T) {
 	assert.Equal(t, []int{1}, order)
 }
 
-func TestWatchCoalesceLastEventWins(t *testing.T) {
+func TestWatchCoalesceCreatedThenUpdatedStaysCreated(t *testing.T) {
 	pending := make(map[int]Event)
 	var order []int
 
 	order = coalesceWatchEvent(pending, order, Event{Type: EventCreated, ID: 1})
+	order = coalesceWatchEvent(pending, order, Event{Type: EventUpdated, ID: 1})
+
+	assert.Equal(t, Event{Type: EventCreated, ID: 1}, pending[1])
+	assert.Equal(t, []int{1}, order)
+}
+
+func TestWatchCoalesceLastEventWins(t *testing.T) {
+	pending := make(map[int]Event)
+	var order []int
+
 	order = coalesceWatchEvent(pending, order, Event{Type: EventUpdated, ID: 1})
 	order = coalesceWatchEvent(pending, order, Event{Type: EventDeleted, ID: 1})
 
@@ -45,11 +53,21 @@ func TestWatchCoalesceDeleteCreateIsUpdate(t *testing.T) {
 	assert.Equal(t, []int{1}, order)
 }
 
+func TestWatchCoalesceRecreateAfterCreateDeleteKeepsSingleOrderEntry(t *testing.T) {
+	pending := make(map[int]Event)
+	var order []int
+
+	order = coalesceWatchEvent(pending, order, Event{Type: EventCreated, ID: 1})
+	order = coalesceWatchEvent(pending, order, Event{Type: EventDeleted, ID: 1})
+	order = coalesceWatchEvent(pending, order, Event{Type: EventCreated, ID: 1})
+
+	assert.Equal(t, Event{Type: EventCreated, ID: 1}, pending[1])
+	assert.Equal(t, []int{1}, order)
+}
+
 func TestOSStoreWatchCreatedUpdatedDeleted(t *testing.T) {
 	s := newOSTestStore(t)
 	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
-	watchRoot := filepath.Join(s.Root(), "2026", "01")
-	require.NoError(t, os.MkdirAll(watchRoot, StoreDirMode(s.Root())))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -96,8 +114,6 @@ func TestOSStoreWatchDebouncesSameID(t *testing.T) {
 func TestOSStoreWatchCloseWhilePending(t *testing.T) {
 	s := newOSTestStore(t)
 	created := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
-	watchRoot := filepath.Join(s.Root(), "2026", "01")
-	require.NoError(t, os.MkdirAll(watchRoot, StoreDirMode(s.Root())))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary

- Add OSStore.Watch with ID-keyed created/updated/deleted events
- Debounce and coalesce fsnotify events per note ID
- Cover watcher lifecycle and coalescing behavior with tests

## References

- Closes #251