### PR TITLE
Add store reconcile delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.25] - 2026-04-26
+
+### Added
+
+- `note.Store.Reconcile(known)` returns an mtime-keyed `note.Diff` so long-running consumers can cheaply resync added, updated, and removed notes without rereading unchanged files ([#259]).
+
+[#259]: https://github.com/dreikanter/notesctl/pull/259
+
 ## [0.3.24] - 2026-04-26
 
 ### Added

--- a/note/mem_store.go
+++ b/note/mem_store.go
@@ -118,6 +118,36 @@ func (s *MemStore) Delete(id int) error {
 	return nil
 }
 
+// Reconcile returns the delta between known and the current in-memory state.
+// known maps entry ID to the UpdatedAt timestamp the caller last observed.
+func (s *MemStore) Reconcile(known map[int]time.Time) (Diff, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	seen := make(map[int]struct{}, len(s.entries))
+	var diff Diff
+	for id, entry := range s.entries {
+		seen[id] = struct{}{}
+		knownTime, ok := known[id]
+		if !ok {
+			diff.Added = append(diff.Added, entry)
+			continue
+		}
+		if !knownTime.Equal(entry.Meta.UpdatedAt) {
+			diff.Updated = append(diff.Updated, entry)
+		}
+	}
+	for id := range known {
+		if _, ok := seen[id]; !ok {
+			diff.Removed = append(diff.Removed, id)
+		}
+	}
+	s.sortEntriesByRecency(diff.Added)
+	s.sortEntriesByRecency(diff.Updated)
+	sort.Ints(diff.Removed)
+	return diff, nil
+}
+
 // matchLocked returns every entry that matches q. Caller holds s.mu for
 // read (RLock or Lock).
 func (s *MemStore) matchLocked(q query) []Entry {

--- a/note/os_store.go
+++ b/note/os_store.go
@@ -131,6 +131,68 @@ func (s *OSStore) IDs() ([]int, error) {
 	return ids, nil
 }
 
+// Reconcile returns the delta between known and the current on-disk state.
+// known maps note ID to the file mtime the caller last observed, usually from
+// Entry.Meta.UpdatedAt returned by All, Get, Find, or a previous Reconcile.
+// Files whose mtimes match known are skipped entirely: no file read and no YAML
+// parse. Files whose mtimes differ are read and parsed, even when the on-disk
+// mtime moved backwards; mtime equality is the cache key. Do not seed known
+// from the Entry returned by Put: Put avoids an extra stat and its UpdatedAt is
+// the write time, not necessarily the exact filesystem mtime.
+//
+// Caveats: filesystem mtime resolution can coalesce rapid writes on some
+// filesystems, so a rewrite inside that resolution may be missed; tools such as
+// rsync or touch can set mtimes backwards, which is why Reconcile compares
+// equality rather than newer-than; a rename that changes the ID-bearing
+// filename prefix appears as Removed+Added.
+func (s *OSStore) Reconcile(known map[int]time.Time) (Diff, error) {
+	refs, err := s.scanFileRefs()
+	if err != nil {
+		return Diff{}, err
+	}
+
+	seen := make(map[int]struct{}, len(refs))
+	var diff Diff
+	for _, ref := range refs {
+		path := ref.absPath(s.root)
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return Diff{}, err
+		}
+
+		modTime := info.ModTime()
+		if knownTime, ok := known[ref.id]; ok && knownTime.Equal(modTime) {
+			seen[ref.id] = struct{}{}
+			continue
+		}
+
+		entry, err := s.readEntry(ref)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return Diff{}, err
+		}
+		seen[ref.id] = struct{}{}
+		if _, ok := known[ref.id]; ok {
+			diff.Updated = append(diff.Updated, entry)
+		} else {
+			diff.Added = append(diff.Added, entry)
+		}
+	}
+
+	for id := range known {
+		if _, ok := seen[id]; !ok {
+			diff.Removed = append(diff.Removed, id)
+		}
+	}
+	sort.Ints(diff.Removed)
+	return diff, nil
+}
+
 // refMatchesFilename evaluates the subset of q that can be answered from the
 // filename alone: WithType, WithSlug, WithExactDate, WithBeforeDate.
 // Body-dependent filters (WithTag) are always passed as matching at this

--- a/note/os_store_test.go
+++ b/note/os_store_test.go
@@ -245,10 +245,96 @@ func TestOSStore_AllFilterByPublic(t *testing.T) {
 	assert.False(t, priv[0].Meta.Public)
 }
 
+func TestOSStore_ReconcileUnchangedSkipsFileReadAndParse(t *testing.T) {
+	s := newOSTestStore(t)
+	entry, err := s.Put(Entry{Meta: Meta{CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}, Body: "body"})
+	require.NoError(t, err)
+	path := s.AbsPath(entry)
+	modTime := fileModTime(t, path)
+
+	// If Reconcile reads this file despite the matching mtime, the malformed
+	// frontmatter will fail the test. Reset the mtime to simulate an unchanged
+	// cache key.
+	require.NoError(t, os.WriteFile(path, []byte("---\n: bad\n---\nbody"), 0o644))
+	require.NoError(t, os.Chtimes(path, modTime, modTime))
+
+	diff, err := s.Reconcile(map[int]time.Time{entry.ID: modTime.In(time.FixedZone("offset", 3600))})
+	require.NoError(t, err)
+	assert.Empty(t, diff.Added)
+	assert.Empty(t, diff.Updated)
+	assert.Empty(t, diff.Removed)
+}
+
+func TestOSStore_ReconcileUpdatedAddedAndRemoved(t *testing.T) {
+	s := newOSTestStore(t)
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	updated, err := s.Put(Entry{Meta: Meta{CreatedAt: created}, Body: "old"})
+	require.NoError(t, err)
+	oldModTime := fileModTime(t, s.AbsPath(updated))
+
+	added, err := s.Put(Entry{Meta: Meta{CreatedAt: created.Add(24 * time.Hour)}, Body: "new"})
+	require.NoError(t, err)
+
+	updatedPath := s.AbsPath(updated)
+	require.NoError(t, os.WriteFile(updatedPath, []byte("changed"), 0o644))
+	newModTime := oldModTime.Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(updatedPath, newModTime, newModTime))
+
+	diff, err := s.Reconcile(map[int]time.Time{updated.ID: oldModTime, 99: oldModTime})
+	require.NoError(t, err)
+	assertEntryIDsUnordered(t, []int{added.ID}, diff.Added)
+	assertEntryIDsUnordered(t, []int{updated.ID}, diff.Updated)
+	assert.Equal(t, "changed", diff.Updated[0].Body)
+	assert.Equal(t, []int{99}, diff.Removed)
+}
+
+func TestOSStore_ReconcileMTimeSetBackwardsStillDetected(t *testing.T) {
+	s := newOSTestStore(t)
+	entry, err := s.Put(Entry{Meta: Meta{CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}, Body: "body"})
+	require.NoError(t, err)
+	path := s.AbsPath(entry)
+	current := fileModTime(t, path)
+	backwards := current.Add(-time.Hour)
+	require.NoError(t, os.Chtimes(path, backwards, backwards))
+
+	diff, err := s.Reconcile(map[int]time.Time{entry.ID: current})
+	require.NoError(t, err)
+	assertEntryIDsUnordered(t, []int{entry.ID}, diff.Updated)
+}
+
+func TestOSStore_ReconcileSkipsFileWithNoParseableID(t *testing.T) {
+	s := newOSTestStore(t)
+	dir := filepath.Join(s.Root(), "2026", "01")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "not-a-note.md"), []byte("body"), 0o644))
+
+	diff, err := s.Reconcile(nil)
+	require.NoError(t, err)
+	assert.Empty(t, diff.Added)
+	assert.Empty(t, diff.Updated)
+	assert.Empty(t, diff.Removed)
+}
+
 func assertFileExists(t *testing.T, path string) {
 	t.Helper()
 	_, err := os.Stat(path)
 	require.NoError(t, err)
+}
+
+func assertEntryIDsUnordered(t *testing.T, want []int, entries []Entry) {
+	t.Helper()
+	got := make([]int, len(entries))
+	for i, e := range entries {
+		got[i] = e.ID
+	}
+	assert.ElementsMatch(t, want, got)
+}
+
+func fileModTime(t *testing.T, path string) time.Time {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	return info.ModTime()
 }
 
 func assertNoFile(t *testing.T, path string) {

--- a/note/store.go
+++ b/note/store.go
@@ -1,6 +1,9 @@
 package note
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
 
 // ErrNotFound is the package-wide "entry not found" sentinel. It is returned
 // (wrapped) by Store.Get, Store.Find, and Store.Delete when no entry matches.
@@ -8,6 +11,19 @@ import "errors"
 //
 //	if errors.Is(err, note.ErrNotFound) { … }
 var ErrNotFound = errors.New("entry not found")
+
+// Diff is the result of a Reconcile call: what changed since the caller's
+// last known view of the store.
+type Diff struct {
+	// Added contains entries whose IDs were not present in the caller's known map.
+	Added []Entry
+	// Updated contains entries whose IDs were present in known with a different
+	// modification time. Stores compare mtimes for equality, not freshness, so
+	// callers also detect files whose mtimes moved backwards.
+	Updated []Entry
+	// Removed contains IDs from known that no longer exist in the store.
+	Removed []int
+}
 
 // Store is the backend abstraction the note package exposes. Implementations
 // encapsulate the storage substrate (filesystem, in-memory, future cloud/DB)
@@ -50,4 +66,11 @@ type Store interface {
 	// Delete removes the entry with the given ID. Returns ErrNotFound when
 	// no entry has that ID.
 	Delete(id int) error
+
+	// Reconcile returns the delta between known and the current store state.
+	// known maps entry ID to the mtime the caller last observed for that ID.
+	// Entries with matching mtimes are skipped; changed entries are returned
+	// fully populated. Use this for cheap periodic resync; use All for an
+	// initial load.
+	Reconcile(known map[int]time.Time) (Diff, error)
 }


### PR DESCRIPTION
## Summary

- add `note.Diff` and `Store.Reconcile` for mtime-keyed incremental store resyncs
- implement cheap filesystem reconciliation for `OSStore` and matching in-memory behavior for `MemStore`
- cover unchanged, added, updated, removed, backwards-mtime, and unparseable-filename cases

## References

- Closes #257
