### PR TITLE
Rename NOTESCTL_PATH environment variable to NOTES_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ $EDITOR "$(notes resolve --slug meeting)"
 The notes store path is resolved in this order:
 
 1. `--path` flag
-2. `NOTESCTL_PATH` environment variable
+2. `NOTES_PATH` environment variable
 
 If neither is set, `notes` exits with an error. There is no implicit default —
-set `NOTESCTL_PATH` (e.g. `export NOTESCTL_PATH=~/notes`) or pass `--path`.
+set `NOTES_PATH` (e.g. `export NOTES_PATH=~/notes`) or pass `--path`.
 
 ## Development
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,7 +30,7 @@ func init() {
 		}
 	}
 	rootCmd.Version = Version
-	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes store (default: $NOTESCTL_PATH)")
+	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes store (default: $NOTES_PATH)")
 }
 
 func Execute() {
@@ -47,10 +47,10 @@ func resolveNotesPath() (string, error) {
 	if notesPath != "" {
 		return notesPath, nil
 	}
-	if env := os.Getenv("NOTESCTL_PATH"); env != "" {
+	if env := os.Getenv("NOTES_PATH"); env != "" {
 		return env, nil
 	}
-	return "", errors.New("no notes store configured. Set $NOTESCTL_PATH or pass --path")
+	return "", errors.New("no notes store configured. Set $NOTES_PATH or pass --path")
 }
 
 func notesRoot() (string, error) {
@@ -74,7 +74,7 @@ func notesRoot() (string, error) {
 
 // notesStore returns the Store instance the CLI uses for note-package
 // operations. It resolves the root path the same way notesRoot does — flag
-// first, then $NOTESCTL_PATH, then error.
+// first, then $NOTES_PATH, then error.
 func notesStore() (*note.OSStore, error) {
 	root, err := notesRoot()
 	if err != nil {


### PR DESCRIPTION
## Summary

Rename the `NOTESCTL_PATH` environment variable to `NOTES_PATH` throughout the codebase for consistency and clarity. This includes updates to:

- Flag help text in `root.go`
- Environment variable resolution logic in `resolveNotesPath()`
- Error messages
- Code comments
- README documentation

The functionality remains unchanged; this is purely a naming update to use a shorter, more intuitive environment variable name.

## References

- Closes #261
