### PR TITLE
Improve CLI help text clarity and consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Changed
 
+- Rename the configuration environment variable from `NOTESCTL_PATH` back to `NOTES_PATH`, restoring the shorter name. Update `--path` help, error messages, README, and the `resolveNotesPath` lookup accordingly ([#262]).
 - Streamline CLI help text: drop "by numeric ID" from `read`/`rm` short descriptions and the `resolve --id` flag, drop redundant "for frontmatter" / "in frontmatter" suffixes from `new` and `update` flags, replace internal "file cache suffix" jargon in `update` with plain "file is renamed", and tighten the `resolve` long help and a few other phrasings ([#263]).
 
+[#262]: https://github.com/dreikanter/notesctl/pull/262
 [#263]: https://github.com/dreikanter/notesctl/pull/263
 
 ## [0.3.26] - 2026-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.3.28] - 2026-04-27
+
+### Changed
+
+- Streamline CLI help text: drop "by numeric ID" from `read`/`rm` short descriptions and the `resolve --id` flag, drop redundant "for frontmatter" / "in frontmatter" suffixes from `new` and `update` flags, replace internal "file cache suffix" jargon in `update` with plain "file is renamed", and tighten the `resolve` long help and a few other phrasings ([#263]).
+
+[#263]: https://github.com/dreikanter/notesctl/pull/263
+
+## [0.3.27] - 2026-04-27
+
+### Changed
+
+- Rename the configuration environment variable from `NOTESCTL_PATH` back to `NOTES_PATH`, restoring the shorter name. Update `--path` help, error messages, README, and the `resolveNotesPath` lookup accordingly ([#262]).
+
+[#262]: https://github.com/dreikanter/notesctl/pull/262
+
 ## [0.3.26] - 2026-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,12 @@
 # Changelog
 
-## [0.3.28] - 2026-04-27
+## [0.3.27] - 2026-04-27
 
 ### Changed
 
 - Streamline CLI help text: drop "by numeric ID" from `read`/`rm` short descriptions and the `resolve --id` flag, drop redundant "for frontmatter" / "in frontmatter" suffixes from `new` and `update` flags, replace internal "file cache suffix" jargon in `update` with plain "file is renamed", and tighten the `resolve` long help and a few other phrasings ([#263]).
 
 [#263]: https://github.com/dreikanter/notesctl/pull/263
-
-## [0.3.27] - 2026-04-27
-
-### Changed
-
-- Rename the configuration environment variable from `NOTESCTL_PATH` back to `NOTES_PATH`, restoring the shorter name. Update `--path` help, error messages, README, and the `resolveNotesPath` lookup accordingly ([#262]).
-
-[#262]: https://github.com/dreikanter/notesctl/pull/262
 
 ## [0.3.26] - 2026-04-26
 

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -48,7 +48,7 @@ Generate concise metadata for the provided note body, returning ONLY the fields 
 
 var annotateCmd = &cobra.Command{
 	Use:   "annotate <id>",
-	Short: "Fill empty frontmatter (title, description, tags) using Claude Code CLI",
+	Short: "Fill empty frontmatter (title, description, tags) using Claude Code",
 	Args:  cobra.ExactArgs(1),
 	RunE:  annotateRunE,
 }
@@ -271,7 +271,7 @@ func mergeAnnotation(existing note.Meta, gen annotateResult) note.Meta {
 func registerAnnotateFlags() {
 	annotateCmd.Flags().String("model", annotateDefaultModel, "Claude model to use")
 	annotateCmd.Flags().Int("max-chars", 0, "truncate note body to this many characters before annotating (0 = no limit)")
-	annotateCmd.Flags().Duration("timeout", annotateDefaultTimeout, "maximum time to wait for the claude CLI to respond (0 = no timeout)")
+	annotateCmd.Flags().Duration("timeout", annotateDefaultTimeout, "maximum time to wait for Claude to respond (0 = no timeout)")
 }
 
 func init() {

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -92,13 +92,13 @@ func findUpsertEntry(store note.Store, noteType, slug string) (note.Entry, bool,
 }
 
 func registerNewFlags() {
-	newCmd.Flags().String("slug", "", "descriptive slug appended to filename")
-	newCmd.Flags().String("type", "", "note type (free-form; todo/backlog/weekly get special behavior)")
-	newCmd.Flags().StringSlice("tag", nil, "tag for frontmatter (repeatable)")
-	newCmd.Flags().String("description", "", "description for frontmatter")
-	newCmd.Flags().String("title", "", "title for frontmatter")
-	newCmd.Flags().Bool("public", false, "mark note as public in frontmatter (private is the default)")
-	newCmd.Flags().Bool("upsert", false, "return existing note if today already has one matching --type/--slug")
+	newCmd.Flags().String("slug", "", "descriptive slug for the note")
+	newCmd.Flags().String("type", "", "note type (free-form; todo/backlog/weekly get special handling)")
+	newCmd.Flags().StringSlice("tag", nil, "tag (repeatable)")
+	newCmd.Flags().String("description", "", "note description")
+	newCmd.Flags().String("title", "", "note title")
+	newCmd.Flags().Bool("public", false, "mark note as public (private is the default)")
+	newCmd.Flags().Bool("upsert", false, "reuse today's note if one already matches --type/--slug")
 }
 
 func init() {

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -12,7 +12,7 @@ import (
 
 var readCmd = &cobra.Command{
 	Use:   "read <id>",
-	Short: "Read a note by numeric ID",
+	Short: "Read a note",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id, err := strconv.Atoi(args[0])

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -11,8 +11,8 @@ import (
 
 var resolveCmd = &cobra.Command{
 	Use:   "resolve",
-	Short: "Print the absolute path of a note by explicit lookup flag",
-	Long: `Resolve a note by an explicit lookup flag and print its absolute path.
+	Short: "Print the absolute path of a note",
+	Long: `Print the absolute path of a note.
 
   notes resolve               - most recent note
   notes resolve --id <id>     - exact ID
@@ -20,7 +20,7 @@ var resolveCmd = &cobra.Command{
   notes resolve --slug <s>    - most recent note with that slug
   notes resolve --tag <t>     - most recent note with that tag
 
-Exactly one lookup flag (or none) may be provided.`,
+At most one lookup flag may be provided.`,
 	Args: cobra.NoArgs,
 	RunE: resolveRunE,
 }
@@ -89,7 +89,7 @@ func lookupEntry(store *note.OSStore, idStr, noteType, slug, tag string) (note.E
 }
 
 func registerResolveFlags() {
-	resolveCmd.Flags().String("id", "", "resolve by exact numeric ID")
+	resolveCmd.Flags().String("id", "", "resolve by ID")
 	resolveCmd.Flags().String("type", "", "resolve the most recent note with the given type")
 	resolveCmd.Flags().String("slug", "", "resolve the most recent note with the given slug")
 	resolveCmd.Flags().String("tag", "", "resolve the most recent note with the given tag")

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -11,7 +11,7 @@ import (
 
 var rmCmd = &cobra.Command{
 	Use:   "rm <id>",
-	Short: "Delete a note by numeric ID",
+	Short: "Delete a note",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id, err := strconv.Atoi(args[0])

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -13,7 +13,7 @@ import (
 
 var updateCmd = &cobra.Command{
 	Use:   "update <id>",
-	Short: "Update frontmatter fields on a note (rename is automatic on slug/type/date changes)",
+	Short: "Update note frontmatter (file is renamed automatically when slug, type, or date changes)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		id, err := strconv.Atoi(args[0])
@@ -110,17 +110,17 @@ var updateCmd = &cobra.Command{
 }
 
 func registerUpdateFlags() {
-	updateCmd.Flags().StringSlice("tag", nil, "tag for frontmatter (repeatable); replaces existing tags")
-	updateCmd.Flags().Bool("no-tags", false, "remove all tags from frontmatter")
-	updateCmd.Flags().String("title", "", "title for frontmatter (empty string clears it)")
-	updateCmd.Flags().String("description", "", "description for frontmatter (empty string clears it)")
-	updateCmd.Flags().String("slug", "", "slug for frontmatter; file is renamed to match")
-	updateCmd.Flags().Bool("no-slug", false, "remove slug from frontmatter; file is renamed to match")
-	updateCmd.Flags().String("type", "", "note type; file cache suffix is rewritten to match")
-	updateCmd.Flags().Bool("no-type", false, "remove type; file cache suffix is stripped to match")
-	updateCmd.Flags().Bool("public", false, "mark note as public in frontmatter")
-	updateCmd.Flags().Bool("private", false, "mark note as private in frontmatter")
-	updateCmd.Flags().String("date", "", "move the note to this date (YYYYMMDD); affects the year/month directory and filename prefix")
+	updateCmd.Flags().StringSlice("tag", nil, "tag (repeatable); replaces existing tags")
+	updateCmd.Flags().Bool("no-tags", false, "remove all tags")
+	updateCmd.Flags().String("title", "", "note title (empty string clears it)")
+	updateCmd.Flags().String("description", "", "note description (empty string clears it)")
+	updateCmd.Flags().String("slug", "", "set slug; file is renamed to match")
+	updateCmd.Flags().Bool("no-slug", false, "remove slug; file is renamed to match")
+	updateCmd.Flags().String("type", "", "set note type; file is renamed to match")
+	updateCmd.Flags().Bool("no-type", false, "remove type; file is renamed to match")
+	updateCmd.Flags().Bool("public", false, "mark note as public")
+	updateCmd.Flags().Bool("private", false, "mark note as private")
+	updateCmd.Flags().String("date", "", "move the note to this date (YYYYMMDD); file is moved to match")
 	updateCmd.MarkFlagsMutuallyExclusive("slug", "no-slug")
 	updateCmd.MarkFlagsMutuallyExclusive("type", "no-type")
 	updateCmd.MarkFlagsMutuallyExclusive("tag", "no-tags")


### PR DESCRIPTION
## Summary

Streamlined and standardized help text across CLI commands for improved clarity and consistency. Changes focus on:

- Removing redundant phrases like "for frontmatter" and "by numeric ID"
- Using more concise, direct language in flag descriptions
- Improving consistency in terminology (e.g., "file is renamed to match" vs "file cache suffix is rewritten")
- Simplifying command short descriptions to be more scannable

## Changes

- **update.go**: Simplified flag descriptions and command short text; clarified that file renaming happens automatically for slug/type/date changes
- **new.go**: Shortened flag descriptions to focus on what the flag does rather than implementation details
- **resolve.go**: Simplified command descriptions and changed "Exactly one" to "At most one" to accurately reflect the behavior
- **annotate.go**: Minor text improvements ("Claude Code CLI" → "Claude Code", "claude CLI" → "Claude")
- **read.go** & **rm.go**: Removed redundant "by numeric ID" from short descriptions

All changes are documentation-only with no functional impact.

https://claude.ai/code/session_017qbuut3LpQSFk6dcbzXqeZ