### PR TITLE
Track explicit vs. implicit CreatedAt dates in frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.28] - 2026-04-29
+
+### Changed
+
+- Track whether a note's `CreatedAt` came from an explicit frontmatter `date` (or `update --date`) vs. the filename UID fallback, and only emit the `date` field on write when it was explicit. `notes new` no longer stamps a redundant auto-generated date into the frontmatter; the filename remains the canonical source per `SCHEMA.md` ([#264]).
+
+[#264]: https://github.com/dreikanter/notesctl/pull/264
+
 ## [0.3.27] - 2026-04-27
 
 ### Changed

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -39,6 +39,15 @@ func TestNewDefault(t *testing.T) {
 	}
 }
 
+func TestNewOmitsAutoDateFrontmatter(t *testing.T) {
+	root := copyTestdata(t)
+	out, err := runNew(t, root, "")
+	require.NoError(t, err)
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "date:")
+}
+
 func TestNewWithSlug(t *testing.T) {
 	root := copyTestdata(t)
 	out, err := runNew(t, root, "", "--slug", "myslug")

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -97,6 +97,7 @@ var updateCmd = &cobra.Command{
 		}
 		if cmd.Flags().Changed("date") {
 			entry.Meta.CreatedAt = newDate
+			entry.Meta.DateExplicit = true
 		}
 
 		saved, err := store.Put(entry)

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -120,6 +120,9 @@ func TestUpdateDateMovesFile(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(root, "2026/01/20260106_8823_999.md")); !os.IsNotExist(err) {
 		t.Errorf("old file should be gone, err=%v", err)
 	}
+	data, err := os.ReadFile(want)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "date: 2026-03-01")
 }
 
 func TestUpdateDateInvalidFormat(t *testing.T) {

--- a/note/domain.go
+++ b/note/domain.go
@@ -12,8 +12,16 @@ type Entry struct {
 // Meta holds the user-domain metadata for a note. YAML serialisation details
 // live inside OSStore.
 //
-// CreatedAt maps to the YAML frontmatter "date" field and is both read from
-// and written to disk.
+// CreatedAt is the canonical authored timestamp. It always carries a value
+// in memory: read from the frontmatter "date" field when present, otherwise
+// derived from the filename's UID date prefix. It only round-trips back to
+// the YAML "date" field when DateExplicit is true; otherwise the field is
+// omitted on write and consumers fall back to the filename per SCHEMA.md.
+//
+// DateExplicit reports that CreatedAt came from a user-supplied frontmatter
+// "date" (on read) or a user-driven CLI flag like `update --date` (on write).
+// Auto-defaulted dates (e.g. `notes new` stamping time.Now into a fresh
+// entry) leave it false so the redundant frontmatter line is suppressed.
 //
 // UpdatedAt is derived from the file's ModTime on read and is never written
 // to YAML. OSStore.Put sets it to time.Now on every write — no file re-read
@@ -26,14 +34,15 @@ type Entry struct {
 // Extra carries unknown frontmatter keys as map[string]any; OSStore handles
 // conversion to/from yaml.Node at the serialisation boundary.
 type Meta struct {
-	Title       string
-	Slug        string
-	Type        string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	Tags        []string
-	Aliases     []string
-	Description string
-	Public      bool
-	Extra       map[string]any
+	Title        string
+	Slug         string
+	Type         string
+	CreatedAt    time.Time
+	DateExplicit bool
+	UpdatedAt    time.Time
+	Tags         []string
+	Aliases      []string
+	Description  string
+	Public       bool
+	Extra        map[string]any
 }

--- a/note/os_store.go
+++ b/note/os_store.go
@@ -462,9 +462,11 @@ func (s *OSStore) pathFor(entry Entry) (rel, abs string) {
 // frontmatterToMeta converts the on-disk frontmatter into the public
 // Meta. Body hashtags are merged into Meta.Tags; Meta.UpdatedAt is set
 // from the file ModTime; Meta.CreatedAt falls back to the filename date when
-// the frontmatter has no date.
+// the frontmatter has no date. DateExplicit reflects whether the source was
+// the frontmatter (true) or the filename fallback (false).
 func frontmatterToMeta(fm frontmatter, r fileRef, modTime time.Time, body []byte) Meta {
 	created := fm.Date
+	dateExplicit := !fm.Date.IsZero()
 	if created.IsZero() {
 		if t, err := time.Parse(DateFormat, r.date); err == nil {
 			created = t
@@ -480,22 +482,26 @@ func frontmatterToMeta(fm frontmatter, r fileRef, modTime time.Time, body []byte
 	}
 
 	return Meta{
-		Title:       fm.Title,
-		Slug:        slug,
-		Type:        noteType,
-		CreatedAt:   created,
-		UpdatedAt:   modTime,
-		Tags:        computeMergedTags(fm.Tags, normalizeHashtags(ExtractHashtags(body))),
-		Aliases:     append([]string(nil), fm.Aliases...),
-		Description: fm.Description,
-		Public:      fm.Public,
-		Extra:       extraFromYAML(fm.Extra),
+		Title:        fm.Title,
+		Slug:         slug,
+		Type:         noteType,
+		CreatedAt:    created,
+		DateExplicit: dateExplicit,
+		UpdatedAt:    modTime,
+		Tags:         computeMergedTags(fm.Tags, normalizeHashtags(ExtractHashtags(body))),
+		Aliases:      append([]string(nil), fm.Aliases...),
+		Description:  fm.Description,
+		Public:       fm.Public,
+		Extra:        extraFromYAML(fm.Extra),
 	}
 }
 
 // metaToFrontmatter converts Meta into the on-disk frontmatter. Body
 // hashtags are *not* stripped from Meta.Tags — they round-trip through the
-// frontmatter alongside the originals. UpdatedAt is never written.
+// frontmatter alongside the originals. UpdatedAt is never written. The
+// "date" field is only emitted when Meta.DateExplicit is true; auto-
+// defaulted dates stay implicit and consumers reconstruct them from the
+// filename per SCHEMA.md.
 func metaToFrontmatter(m Meta) frontmatter {
 	var aliases []string
 	if len(m.Aliases) > 0 {
@@ -505,11 +511,15 @@ func metaToFrontmatter(m Meta) frontmatter {
 	if len(m.Tags) > 0 {
 		tags = append([]string(nil), m.Tags...)
 	}
+	var date time.Time
+	if m.DateExplicit {
+		date = m.CreatedAt
+	}
 	return frontmatter{
 		Title:       m.Title,
 		Slug:        m.Slug,
 		Type:        m.Type,
-		Date:        m.CreatedAt,
+		Date:        date,
 		Tags:        tags,
 		Aliases:     aliases,
 		Description: m.Description,


### PR DESCRIPTION
## Summary

Add a `DateExplicit` field to `Meta` to distinguish between user-supplied dates (from frontmatter or CLI flags) and auto-defaulted dates (from filename fallback). When writing frontmatter, only emit the "date" field if `DateExplicit` is true, allowing auto-defaulted dates to remain implicit and be reconstructed from the filename.

This reduces redundant frontmatter and makes the distinction between explicit and implicit dates explicit in the domain model.

## Changes

- **domain.go**: Add `DateExplicit bool` field to `Meta` struct with documentation explaining its semantics
- **os_store.go**: 
  - Track whether `CreatedAt` came from frontmatter (true) or filename fallback (false) in `frontmatterToMeta`
  - Only write the "date" field to frontmatter in `metaToFrontmatter` when `DateExplicit` is true
  - Update function documentation to explain the new behavior
- **update.go**: Set `DateExplicit = true` when user explicitly provides a `--date` flag
- **Tests**: 
  - Add `TestNewOmitsAutoDateFrontmatter` to verify auto-generated dates don't appear in frontmatter
  - Update `TestUpdateDateMovesFile` to verify explicit dates are written to frontmatter

## References

- Relates to `SCHEMA.md` date handling conventions.