### PR TITLE
Add config command to print effective runtime configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.29]
+
+### Added
+
+- `notes config` prints the effective runtime configuration: the resolved notes store path with its source (flag, env, or unset), the per-command default values for `annotate --model` / `--max-chars` / `--timeout`, and a present/absent indicator for required external env vars (`NOTES_PATH`, `ANTHROPIC_API_KEY`). The store path is validated inline so a missing directory is surfaced in the output without aborting; env var values are never printed ([#266]).
+
+[#266]: https://github.com/dreikanter/notesctl/pull/266
+
 ## [0.3.28] - 2026-04-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ notes update 8823 --private
 
 # List all tags (frontmatter + body hashtags)
 notes tags
+
+# Print the effective runtime configuration (resolved store path, defaults, env vars)
+notes config
 ```
 
 Composing with the shell — since most commands take an ID, use `ls` or

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Print the effective runtime configuration",
+	Long: `Print the effective runtime configuration: the resolved notes store
+path, root flags, per-command default values, and the status of external
+environment variables consumed by subcommands.
+
+Each option is shown with its resolution source — flag, env var, or built-in
+default. The store path is validated inline; problems are surfaced in the
+output without aborting.`,
+	Args: cobra.NoArgs,
+	RunE: configRunE,
+}
+
+func configRunE(cmd *cobra.Command, _ []string) error {
+	printConfig(cmd.OutOrStdout())
+	return nil
+}
+
+func printConfig(out io.Writer) {
+	path, source := resolveStorePathSource()
+	abs, status := validateStorePath(path)
+
+	fmt.Fprintln(out, "Notes store:")
+	switch {
+	case path == "":
+		fmt.Fprintln(out, "  path:    (unset)")
+	case abs != "" && abs != path:
+		fmt.Fprintf(out, "  path:    %s (from %s)\n", abs, path)
+	default:
+		fmt.Fprintf(out, "  path:    %s\n", path)
+	}
+	fmt.Fprintf(out, "  source:  %s\n", source)
+	fmt.Fprintf(out, "  status:  %s\n", status)
+	fmt.Fprintln(out)
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Options:")
+	fmt.Fprintf(w, "  --path\t%s\t%s\n", displayValue(notesPath), pathFlagSource())
+	fmt.Fprintf(w, "  annotate --model\t%s\tdefault\n", annotateDefaultModel)
+	fmt.Fprintf(w, "  annotate --max-chars\t0\tdefault\n")
+	fmt.Fprintf(w, "  annotate --timeout\t%s\tdefault\n", annotateDefaultTimeout)
+	if err := w.Flush(); err != nil {
+		return
+	}
+	fmt.Fprintln(out)
+
+	w = tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Environment:")
+	fmt.Fprintf(w, "  NOTES_PATH\t%s\tnotes store path fallback for --path\n", presenceMark("NOTES_PATH"))
+	fmt.Fprintf(w, "  ANTHROPIC_API_KEY\t%s\trequired by annotate (consumed by claude CLI)\n", presenceMark("ANTHROPIC_API_KEY"))
+	if err := w.Flush(); err != nil {
+		return
+	}
+}
+
+// resolveStorePathSource returns the raw notes store path and the source it
+// came from (flag, env, or unset). Unlike notesRoot, this does not validate
+// the path, so config can report issues without aborting.
+func resolveStorePathSource() (string, string) {
+	if notesPath != "" {
+		return notesPath, "flag (--path)"
+	}
+	if env := os.Getenv("NOTES_PATH"); env != "" {
+		return env, "env (NOTES_PATH)"
+	}
+	return "", "unset"
+}
+
+// validateStorePath resolves the absolute path and reports its status.
+// Returns an empty abs string when path is empty.
+func validateStorePath(path string) (string, string) {
+	if path == "" {
+		return "", "unset (set NOTES_PATH or pass --path)"
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Sprintf("error: %s", err)
+	}
+	info, err := os.Stat(abs)
+	switch {
+	case os.IsNotExist(err):
+		return abs, "error: directory does not exist"
+	case err != nil:
+		return abs, fmt.Sprintf("error: %s", err)
+	case !info.IsDir():
+		return abs, "error: not a directory"
+	}
+	return abs, "ok"
+}
+
+// pathFlagSource reports where the --path flag value came from. The flag
+// itself is the only thing we can directly observe; if it is empty the value
+// is the built-in default ("").
+func pathFlagSource() string {
+	if notesPath != "" {
+		return "flag"
+	}
+	return "default"
+}
+
+func displayValue(s string) string {
+	if s == "" {
+		return `""`
+	}
+	return s
+}
+
+func presenceMark(name string) string {
+	if os.Getenv(name) != "" {
+		return "set"
+	}
+	return "unset"
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runConfig(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"config"}, args...))
+
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+// resetNotesPath restores the global notesPath flag value after a test, so
+// other tests in the package (which rely on an unset state) are unaffected.
+func resetNotesPath(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { notesPath = "" })
+}
+
+func TestConfigPathFromFlag(t *testing.T) {
+	resetNotesPath(t)
+	t.Setenv("NOTES_PATH", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	root := t.TempDir()
+	out, err := runConfig(t, "--path", root)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Notes store:")
+	assert.Contains(t, out, root)
+	assert.Contains(t, out, "source:  flag (--path)")
+	assert.Contains(t, out, "status:  ok")
+	assert.Contains(t, out, "NOTES_PATH")
+	assert.Contains(t, out, "unset")
+	assert.Contains(t, out, "ANTHROPIC_API_KEY")
+}
+
+func TestConfigPathFromEnv(t *testing.T) {
+	resetNotesPath(t)
+	root := t.TempDir()
+	t.Setenv("NOTES_PATH", root)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	out, err := runConfig(t)
+	require.NoError(t, err)
+	assert.Contains(t, out, "source:  env (NOTES_PATH)")
+	assert.Contains(t, out, "status:  ok")
+	assert.Contains(t, out, root)
+	assert.Regexp(t, `NOTES_PATH +set`, out)
+}
+
+func TestConfigPathUnset(t *testing.T) {
+	resetNotesPath(t)
+	t.Setenv("NOTES_PATH", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	out, err := runConfig(t)
+	require.NoError(t, err)
+	assert.Contains(t, out, "path:    (unset)")
+	assert.Contains(t, out, "source:  unset")
+	assert.Contains(t, out, "set NOTES_PATH or pass --path")
+}
+
+func TestConfigPathMissingDirectory(t *testing.T) {
+	resetNotesPath(t)
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv("NOTES_PATH", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	out, err := runConfig(t, "--path", missing)
+	require.NoError(t, err, "config must not error on a broken path; should report inline")
+	assert.Contains(t, out, "directory does not exist")
+}
+
+func TestConfigPathNotADirectory(t *testing.T) {
+	resetNotesPath(t)
+	dir := t.TempDir()
+	file := filepath.Join(dir, "regular.txt")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o644))
+	t.Setenv("NOTES_PATH", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	out, err := runConfig(t, "--path", file)
+	require.NoError(t, err)
+	assert.Contains(t, out, "not a directory")
+}
+
+func TestConfigOptionsAndDefaults(t *testing.T) {
+	resetNotesPath(t)
+	root := t.TempDir()
+	t.Setenv("NOTES_PATH", root)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	out, err := runConfig(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Options:")
+	assert.Contains(t, out, "annotate --model")
+	assert.Contains(t, out, annotateDefaultModel)
+	assert.Contains(t, out, "annotate --max-chars")
+	assert.Contains(t, out, "annotate --timeout")
+	assert.Contains(t, out, annotateDefaultTimeout.String())
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "annotate ") {
+			assert.Contains(t, line, "default")
+		}
+	}
+}
+
+func TestConfigEnvPresenceMarks(t *testing.T) {
+	resetNotesPath(t)
+	root := t.TempDir()
+	t.Setenv("NOTES_PATH", root)
+	t.Setenv("ANTHROPIC_API_KEY", "secret-not-printed")
+
+	out, err := runConfig(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "ANTHROPIC_API_KEY")
+	assert.Contains(t, out, "set")
+	assert.NotContains(t, out, "secret-not-printed", "config must never print env values")
+}


### PR DESCRIPTION
## Summary

- Add `notes config` command that prints the resolved notes store path with its source (flag, env, or unset), the value/source for the `--path` root flag, the per-command default values for `annotate --model` / `--max-chars` / `--timeout`, and a present/absent indicator for env vars consumed by subcommands (`NOTES_PATH`, `ANTHROPIC_API_KEY`).
- Validate the resolved store path inline: a missing directory or non-directory target is surfaced in the `status:` line so `config` stays useful for debugging a broken setup instead of aborting.
- Never print env var values — only their presence — and add tests covering each resolution source, the broken-path branches, and the secret-redaction guarantee.

## References

- Closes #265