### PR TITLE
.1502411993651747:e37acc44739f2e0e205b072c23806bf6_69f4bb19dc48703ced6cd6c3.69f4bb6bdc48703ced6cd6d7.69f4bb6b35253acc1213a391:Trae CN.T(2026/5/1 22:40:43)

### DIFF
--- a/internal/cli/organize.go
+++ b/internal/cli/organize.go
@@ -19,6 +19,12 @@ type organizeMove struct {
 	reason  string
 }
 
+type organizeConflict struct {
+	dstRel string
+	srcs   []string
+	reason string
+}
+
 var organizeCmd = &cobra.Command{
 	Use:   "organize",
 	Short: "Organize notes by year and tags from frontmatter",
@@ -42,9 +48,14 @@ func organizeRunE(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	moves, err := planOrganize(root)
+	moves, conflicts, err := planOrganize(root)
 	if err != nil {
 		return err
+	}
+
+	if len(conflicts) > 0 {
+		printConflicts(cmd.OutOrStdout(), conflicts)
+		return fmt.Errorf("found %d conflict(s), aborting", len(conflicts))
 	}
 
 	if len(moves) == 0 {
@@ -62,7 +73,7 @@ func organizeRunE(cmd *cobra.Command, _ []string) error {
 	return executeMoves(root, moves, cmd.OutOrStdout())
 }
 
-func planOrganize(root string) ([]organizeMove, error) {
+func planOrganize(root string) ([]organizeMove, []organizeConflict, error) {
 	var moves []organizeMove
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -96,14 +107,16 @@ func planOrganize(root string) ([]organizeMove, error) {
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	sort.Slice(moves, func(i, j int) bool {
 		return moves[i].srcRel < moves[j].srcRel
 	})
 
-	return moves, nil
+	conflicts := detectConflicts(root, moves)
+
+	return moves, conflicts, nil
 }
 
 func planSingleFile(root, relPath string) (*organizeMove, error) {
@@ -126,6 +139,50 @@ func planSingleFile(root, relPath string) (*organizeMove, error) {
 		dstRel: dstRel,
 		reason: reason,
 	}, nil
+}
+
+func detectConflicts(root string, moves []organizeMove) []organizeConflict {
+	var conflicts []organizeConflict
+
+	dstToSrcs := make(map[string][]string)
+	for _, m := range moves {
+		dstToSrcs[m.dstRel] = append(dstToSrcs[m.dstRel], m.srcRel)
+	}
+
+	for dstRel, srcs := range dstToSrcs {
+		if len(srcs) > 1 {
+			conflicts = append(conflicts, organizeConflict{
+				dstRel: dstRel,
+				srcs:   srcs,
+				reason: "multiple sources map to same destination",
+			})
+			continue
+		}
+
+		dstAbs := filepath.Join(root, dstRel)
+		if _, err := os.Stat(dstAbs); err == nil {
+			srcRel := srcs[0]
+			srcAbs := filepath.Join(root, srcRel)
+
+			srcInfo, srcErr := os.Stat(srcAbs)
+			dstInfo, dstErr := os.Stat(dstAbs)
+			if srcErr == nil && dstErr == nil && os.SameFile(srcInfo, dstInfo) {
+				continue
+			}
+
+			conflicts = append(conflicts, organizeConflict{
+				dstRel: dstRel,
+				srcs:   srcs,
+				reason: "destination already exists",
+			})
+		}
+	}
+
+	sort.Slice(conflicts, func(i, j int) bool {
+		return conflicts[i].dstRel < conflicts[j].dstRel
+	})
+
+	return conflicts
 }
 
 func computeDestination(srcRel string, date time.Time, tags []string) (string, string) {
@@ -169,6 +226,20 @@ func printPlan(out io.Writer, moves []organizeMove) {
 	for _, m := range moves {
 		padding := strings.Repeat(" ", maxSrcLen-len(m.srcRel))
 		fmt.Fprintf(out, "  %s%s -> %s (%s)\n", m.srcRel, padding, m.dstRel, m.reason)
+	}
+}
+
+func printConflicts(out io.Writer, conflicts []organizeConflict) {
+	fmt.Fprintf(out, "Conflicts detected (%d):\n\n", len(conflicts))
+
+	for i, c := range conflicts {
+		fmt.Fprintf(out, "  Conflict %d: %s\n", i+1, c.dstRel)
+		fmt.Fprintf(out, "    Reason: %s\n", c.reason)
+		fmt.Fprintf(out, "    Sources:\n")
+		for _, src := range c.srcs {
+			fmt.Fprintf(out, "      - %s\n", src)
+		}
+		fmt.Fprintln(out)
 	}
 }
 

--- a/internal/cli/organize.go
+++ b/internal/cli/organize.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dreikanter/notesctl/note"
+	"github.com/spf13/cobra"
+)
+
+type organizeMove struct {
+	srcRel  string
+	dstRel  string
+	reason  string
+}
+
+var organizeCmd = &cobra.Command{
+	Use:   "organize",
+	Short: "Organize notes by year and tags from frontmatter",
+	Long: `Scan all .md files in the notes directory, read their frontmatter
+for tags and date fields, and plan moves to organize them into subdirectories.
+
+By default, this command runs in dry-run mode and only prints the planned moves.
+Use --apply to actually perform the moves.
+
+Notes without frontmatter, or with missing date/tags fields, are moved to
+the 'uncategorized' directory.`,
+	Args: cobra.NoArgs,
+	RunE: organizeRunE,
+}
+
+func organizeRunE(cmd *cobra.Command, _ []string) error {
+	apply, _ := cmd.Flags().GetBool("apply")
+
+	root, err := notesRoot()
+	if err != nil {
+		return err
+	}
+
+	moves, err := planOrganize(root)
+	if err != nil {
+		return err
+	}
+
+	if len(moves) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "No files to organize.")
+		return nil
+	}
+
+	printPlan(cmd.OutOrStdout(), moves)
+
+	if !apply {
+		fmt.Fprintln(cmd.OutOrStdout(), "\nDry-run complete. Use --apply to perform moves.")
+		return nil
+	}
+
+	return executeMoves(root, moves, cmd.OutOrStdout())
+}
+
+func planOrganize(root string) ([]organizeMove, error) {
+	var moves []organizeMove
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(path) != ".md" {
+			return nil
+		}
+
+		relPath, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
+		move, err := planSingleFile(root, relPath)
+		if err != nil {
+			return fmt.Errorf("%s: %w", relPath, err)
+		}
+
+		if move != nil && move.srcRel != move.dstRel {
+			moves = append(moves, *move)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(moves, func(i, j int) bool {
+		return moves[i].srcRel < moves[j].srcRel
+	})
+
+	return moves, nil
+}
+
+func planSingleFile(root, relPath string) (*organizeMove, error) {
+	absPath := filepath.Join(root, relPath)
+
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, err
+	}
+
+	fm, _, err := note.ParseNote(data)
+	if err != nil {
+		return nil, err
+	}
+
+	dstRel, reason := computeDestination(relPath, fm.Date, fm.Tags)
+
+	return &organizeMove{
+		srcRel: relPath,
+		dstRel: dstRel,
+		reason: reason,
+	}, nil
+}
+
+func computeDestination(srcRel string, date time.Time, tags []string) (string, string) {
+	hasDate := !date.IsZero()
+	hasTags := len(tags) > 0
+
+	if !hasDate || !hasTags {
+		base := filepath.Base(srcRel)
+		return filepath.Join("uncategorized", base), "uncategorized (missing date or tags)"
+	}
+
+	year := date.Format("2006")
+	primaryTag := tags[0]
+
+	for _, t := range tags {
+		if t != "" {
+			primaryTag = t
+			break
+		}
+	}
+
+	if primaryTag == "" {
+		base := filepath.Base(srcRel)
+		return filepath.Join("uncategorized", base), "uncategorized (no valid tags)"
+	}
+
+	base := filepath.Base(srcRel)
+	return filepath.Join(year, primaryTag, base), fmt.Sprintf("year=%s, tag=%s", year, primaryTag)
+}
+
+func printPlan(out io.Writer, moves []organizeMove) {
+	fmt.Fprintf(out, "Planned moves (%d):\n\n", len(moves))
+
+	maxSrcLen := 0
+	for _, m := range moves {
+		if len(m.srcRel) > maxSrcLen {
+			maxSrcLen = len(m.srcRel)
+		}
+	}
+
+	for _, m := range moves {
+		padding := strings.Repeat(" ", maxSrcLen-len(m.srcRel))
+		fmt.Fprintf(out, "  %s%s -> %s (%s)\n", m.srcRel, padding, m.dstRel, m.reason)
+	}
+}
+
+func executeMoves(root string, moves []organizeMove, out io.Writer) error {
+	fmt.Fprintln(out, "\nExecuting moves...")
+
+	for _, m := range moves {
+		srcAbs := filepath.Join(root, m.srcRel)
+		dstAbs := filepath.Join(root, m.dstRel)
+
+		dstDir := filepath.Dir(dstAbs)
+		if err := os.MkdirAll(dstDir, note.StoreDirMode(root)); err != nil {
+			return fmt.Errorf("cannot create directory %s: %w", dstDir, err)
+		}
+
+		if _, err := os.Stat(dstAbs); err == nil {
+			return fmt.Errorf("destination already exists: %s", m.dstRel)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("check destination %s: %w", m.dstRel, err)
+		}
+
+		if err := os.Rename(srcAbs, dstAbs); err != nil {
+			return fmt.Errorf("cannot move %s to %s: %w", m.srcRel, m.dstRel, err)
+		}
+
+		fmt.Fprintf(out, "  Moved: %s -> %s\n", m.srcRel, m.dstRel)
+
+		srcDir := filepath.Dir(srcAbs)
+		if srcDir != root {
+			isEmpty, err := isDirEmpty(srcDir)
+			if err == nil && isEmpty {
+				if err := os.Remove(srcDir); err == nil {
+					fmt.Fprintf(out, "  Removed empty directory: %s\n", filepath.Dir(m.srcRel))
+				}
+			}
+		}
+	}
+
+	fmt.Fprintln(out, "\nDone.")
+	return nil
+}
+
+func isDirEmpty(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	names, err := f.Readdirnames(1)
+	if err != nil && err.Error() != "EOF" {
+		return false, err
+	}
+
+	return len(names) == 0, nil
+}
+
+func registerOrganizeFlags() {
+	organizeCmd.Flags().Bool("apply", false, "actually perform the moves (default: dry-run only)")
+}
+
+func init() {
+	registerOrganizeFlags()
+	rootCmd.AddCommand(organizeCmd)
+}

--- a/internal/cli/organize_test.go
+++ b/internal/cli/organize_test.go
@@ -159,6 +159,93 @@ func TestOrganizeNoFiles(t *testing.T) {
 	assert.Contains(t, out, "No files to organize")
 }
 
+func TestOrganizeConflictExistingFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "organize-conflict-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	note1 := `---
+date: 2024-05-15
+tags: [work]
+---
+
+# Note 1
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "note1.md"), []byte(note1), 0o644)
+	require.NoError(t, err)
+
+	existingDir := filepath.Join(tmpDir, "2024", "work")
+	err = os.MkdirAll(existingDir, 0o755)
+	require.NoError(t, err)
+
+	existingNote := `---
+date: 2024-01-01
+tags: [old]
+---
+
+# Existing Note
+`
+	err = os.WriteFile(filepath.Join(existingDir, "note1.md"), []byte(existingNote), 0o644)
+	require.NoError(t, err)
+
+	out, err := runOrganize(t, tmpDir)
+	require.Error(t, err)
+	assert.Contains(t, out, "Conflicts detected")
+	assert.Contains(t, out, "2024/work/note1.md")
+	assert.Contains(t, out, "destination already exists")
+	assert.Contains(t, out, "note1.md")
+
+	_, err = os.Stat(filepath.Join(tmpDir, "note1.md"))
+	require.NoError(t, err, "original file should not be moved when conflict detected")
+
+	_, err = os.Stat(filepath.Join(existingDir, "note1.md"))
+	require.NoError(t, err, "existing file should not be modified")
+}
+
+func TestOrganizeConflictMultipleSources(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "organize-conflict-multi-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	note1 := `---
+date: 2024-05-15
+tags: [work]
+---
+
+# Note 1
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "note1.md"), []byte(note1), 0o644)
+	require.NoError(t, err)
+
+	subDir := filepath.Join(tmpDir, "subdir")
+	err = os.Mkdir(subDir, 0o755)
+	require.NoError(t, err)
+
+	note2 := `---
+date: 2024-06-20
+tags: [work]
+---
+
+# Note 2 (same filename)
+`
+	err = os.WriteFile(filepath.Join(subDir, "note1.md"), []byte(note2), 0o644)
+	require.NoError(t, err)
+
+	out, err := runOrganize(t, tmpDir)
+	require.Error(t, err)
+	assert.Contains(t, out, "Conflicts detected")
+	assert.Contains(t, out, "2024/work/note1.md")
+	assert.Contains(t, out, "multiple sources map to same destination")
+	assert.Contains(t, out, "note1.md")
+	assert.Contains(t, out, "subdir/note1.md")
+
+	_, err = os.Stat(filepath.Join(tmpDir, "note1.md"))
+	require.NoError(t, err, "original note1 should not be moved")
+
+	_, err = os.Stat(filepath.Join(subDir, "note1.md"))
+	require.NoError(t, err, "subdir/note1 should not be moved")
+}
+
 func TestComputeDestination(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/cli/organize_test.go
+++ b/internal/cli/organize_test.go
@@ -202,6 +202,51 @@ tags: [old]
 	require.NoError(t, err, "existing file should not be modified")
 }
 
+func TestOrganizeConflictExistingFileApply(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "organize-conflict-apply-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	note1 := `---
+date: 2024-05-15
+tags: [work]
+---
+
+# Note 1
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "note1.md"), []byte(note1), 0o644)
+	require.NoError(t, err)
+
+	existingDir := filepath.Join(tmpDir, "2024", "work")
+	err = os.MkdirAll(existingDir, 0o755)
+	require.NoError(t, err)
+
+	existingNote := `---
+date: 2024-01-01
+tags: [old]
+---
+
+# Existing Note
+`
+	existingNotePath := filepath.Join(existingDir, "note1.md")
+	err = os.WriteFile(existingNotePath, []byte(existingNote), 0o644)
+	require.NoError(t, err)
+
+	out, err := runOrganize(t, tmpDir, "--apply")
+	require.Error(t, err)
+	assert.Contains(t, out, "Conflicts detected")
+	assert.Contains(t, out, "2024/work/note1.md")
+	assert.Contains(t, out, "destination already exists")
+	assert.Contains(t, out, "note1.md")
+
+	_, err = os.Stat(filepath.Join(tmpDir, "note1.md"))
+	require.NoError(t, err, "original file should not be moved when conflict detected with --apply")
+
+	existingContent, err := os.ReadFile(existingNotePath)
+	require.NoError(t, err)
+	assert.Equal(t, existingNote, string(existingContent), "existing file should not be overwritten")
+}
+
 func TestOrganizeConflictMultipleSources(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "organize-conflict-multi-*")
 	require.NoError(t, err)
@@ -244,6 +289,50 @@ tags: [work]
 
 	_, err = os.Stat(filepath.Join(subDir, "note1.md"))
 	require.NoError(t, err, "subdir/note1 should not be moved")
+}
+
+func TestOrganizeConflictMultipleSourcesApply(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "organize-conflict-multi-apply-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	note1 := `---
+date: 2024-05-15
+tags: [work]
+---
+
+# Note 1
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "note1.md"), []byte(note1), 0o644)
+	require.NoError(t, err)
+
+	subDir := filepath.Join(tmpDir, "subdir")
+	err = os.Mkdir(subDir, 0o755)
+	require.NoError(t, err)
+
+	note2 := `---
+date: 2024-06-20
+tags: [work]
+---
+
+# Note 2 (same filename)
+`
+	err = os.WriteFile(filepath.Join(subDir, "note1.md"), []byte(note2), 0o644)
+	require.NoError(t, err)
+
+	out, err := runOrganize(t, tmpDir, "--apply")
+	require.Error(t, err)
+	assert.Contains(t, out, "Conflicts detected")
+	assert.Contains(t, out, "2024/work/note1.md")
+	assert.Contains(t, out, "multiple sources map to same destination")
+	assert.Contains(t, out, "note1.md")
+	assert.Contains(t, out, "subdir/note1.md")
+
+	_, err = os.Stat(filepath.Join(tmpDir, "note1.md"))
+	require.NoError(t, err, "original note1 should not be moved with --apply")
+
+	_, err = os.Stat(filepath.Join(subDir, "note1.md"))
+	require.NoError(t, err, "subdir/note1 should not be moved with --apply")
 }
 
 func TestComputeDestination(t *testing.T) {

--- a/internal/cli/organize_test.go
+++ b/internal/cli/organize_test.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestOrganizeDir(t *testing.T) string {
+	t.Helper()
+
+	tmpDir, err := os.MkdirTemp("", "organize-test-*")
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	noteWithFrontmatter := `---
+date: 2024-05-15
+tags: [work, project]
+---
+
+# Test Note
+
+This is a test note.
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "note1.md"), []byte(noteWithFrontmatter), 0o644)
+	require.NoError(t, err)
+
+	noteNoFrontmatter := `# No Frontmatter
+
+This note has no frontmatter.
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "note2.md"), []byte(noteNoFrontmatter), 0o644)
+	require.NoError(t, err)
+
+	noteMissingDate := `---
+tags: [personal]
+---
+
+# Missing Date
+
+This note has tags but no date.
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "note3.md"), []byte(noteMissingDate), 0o644)
+	require.NoError(t, err)
+
+	noteMissingTags := `---
+date: 2024-06-20
+---
+
+# Missing Tags
+
+This note has date but no tags.
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "note4.md"), []byte(noteMissingTags), 0o644)
+	require.NoError(t, err)
+
+	subDir := filepath.Join(tmpDir, "subdir")
+	err = os.Mkdir(subDir, 0o755)
+	require.NoError(t, err)
+
+	noteInSubdir := `---
+date: 2025-03-10
+tags: [review]
+---
+
+# In Subdir
+
+This note is in a subdirectory.
+`
+	err = os.WriteFile(filepath.Join(subDir, "note5.md"), []byte(noteInSubdir), 0o644)
+	require.NoError(t, err)
+
+	return tmpDir
+}
+
+func runOrganize(t *testing.T, root string, args ...string) (string, error) {
+	t.Helper()
+
+	organizeCmd.ResetFlags()
+	registerOrganizeFlags()
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stderr)
+	rootCmd.SetArgs(append([]string{"organize", "--path", root}, args...))
+
+	err := rootCmd.Execute()
+	return strings.TrimSpace(stdout.String()), err
+}
+
+func TestOrganizeDryRun(t *testing.T) {
+	root := createTestOrganizeDir(t)
+
+	out, err := runOrganize(t, root)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Planned moves")
+	assert.Contains(t, out, "note1.md -> 2024/work/note1.md")
+	assert.Contains(t, out, "note2.md -> uncategorized/note2.md")
+	assert.Contains(t, out, "note3.md -> uncategorized/note3.md")
+	assert.Contains(t, out, "note4.md -> uncategorized/note4.md")
+	assert.Contains(t, out, "note5.md -> 2025/review/note5.md")
+	assert.Contains(t, out, "Dry-run complete")
+
+	_, err = os.Stat(filepath.Join(root, "note1.md"))
+	require.NoError(t, err, "file should not be moved in dry-run")
+
+	_, err = os.Stat(filepath.Join(root, "2024"))
+	assert.True(t, os.IsNotExist(err), "directory should not be created in dry-run")
+}
+
+func TestOrganizeApply(t *testing.T) {
+	root := createTestOrganizeDir(t)
+
+	out, err := runOrganize(t, root, "--apply")
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "Executing moves")
+	assert.Contains(t, out, "Moved:")
+	assert.Contains(t, out, "Done.")
+
+	_, err = os.Stat(filepath.Join(root, "2024", "work", "note1.md"))
+	require.NoError(t, err, "note1 should be moved to 2024/work/")
+
+	_, err = os.Stat(filepath.Join(root, "uncategorized", "note2.md"))
+	require.NoError(t, err, "note2 should be moved to uncategorized/")
+
+	_, err = os.Stat(filepath.Join(root, "uncategorized", "note3.md"))
+	require.NoError(t, err, "note3 should be moved to uncategorized/")
+
+	_, err = os.Stat(filepath.Join(root, "uncategorized", "note4.md"))
+	require.NoError(t, err, "note4 should be moved to uncategorized/")
+
+	_, err = os.Stat(filepath.Join(root, "2025", "review", "note5.md"))
+	require.NoError(t, err, "note5 should be moved to 2025/review/")
+
+	_, err = os.Stat(filepath.Join(root, "note1.md"))
+	assert.True(t, os.IsNotExist(err), "original note1 should not exist")
+}
+
+func TestOrganizeNoFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "organize-empty-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	out, err := runOrganize(t, tmpDir)
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "No files to organize")
+}
+
+func TestComputeDestination(t *testing.T) {
+	tests := []struct {
+		name       string
+		srcRel     string
+		date       time.Time
+		tags       []string
+		wantDstRel string
+		wantReason string
+	}{
+		{
+			name:       "valid date and tags",
+			srcRel:     "old/note.md",
+			date:       time.Date(2024, 5, 15, 0, 0, 0, 0, time.UTC),
+			tags:       []string{"work", "project"},
+			wantDstRel: "2024/work/note.md",
+			wantReason: "year=2024, tag=work",
+		},
+		{
+			name:       "missing date",
+			srcRel:     "note.md",
+			date:       time.Time{},
+			tags:       []string{"work"},
+			wantDstRel: "uncategorized/note.md",
+			wantReason: "uncategorized (missing date or tags)",
+		},
+		{
+			name:       "missing tags",
+			srcRel:     "note.md",
+			date:       time.Date(2024, 5, 15, 0, 0, 0, 0, time.UTC),
+			tags:       nil,
+			wantDstRel: "uncategorized/note.md",
+			wantReason: "uncategorized (missing date or tags)",
+		},
+		{
+			name:       "empty tags",
+			srcRel:     "note.md",
+			date:       time.Date(2024, 5, 15, 0, 0, 0, 0, time.UTC),
+			tags:       []string{},
+			wantDstRel: "uncategorized/note.md",
+			wantReason: "uncategorized (missing date or tags)",
+		},
+		{
+			name:       "only empty string tags",
+			srcRel:     "note.md",
+			date:       time.Date(2024, 5, 15, 0, 0, 0, 0, time.UTC),
+			tags:       []string{"", ""},
+			wantDstRel: "uncategorized/note.md",
+			wantReason: "uncategorized (no valid tags)",
+		},
+		{
+			name:       "first tag empty but second valid",
+			srcRel:     "note.md",
+			date:       time.Date(2024, 5, 15, 0, 0, 0, 0, time.UTC),
+			tags:       []string{"", "valid"},
+			wantDstRel: "2024/valid/note.md",
+			wantReason: "year=2024, tag=valid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dstRel, reason := computeDestination(tt.srcRel, tt.date, tt.tags)
+			assert.Equal(t, tt.wantDstRel, dstRel)
+			assert.Equal(t, tt.wantReason, reason)
+		})
+	}
+}


### PR DESCRIPTION
test(cli): 添加--apply标志的冲突测试用例
添加两个测试用例验证在--apply模式下遇到冲突时的行为：
1. 测试目标文件已存在时的冲突处理
2. 测试多个源文件映射到同一目标时的冲突处理