### PR TITLE
Rename module path from notesctl to notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.30]
+
+### Changed
+
+- Rename the Go module path from `github.com/dreikanter/notesctl` to `github.com/dreikanter/notes` to match the renamed GitHub repo. Update internal imports, `Makefile` LDFLAGS, README / CLAUDE / SCHEMA wording, and a few in-code comments. The CLI binary, command name, and `NOTES_PATH` env var are unchanged. Downstream consumers (`npub`, `nview`) must update their imports to the new path ([#270]).
+
+[#270]: https://github.com/dreikanter/notes/pull/270
+
 ## [0.3.29]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# notesctl
+# notes
 
 ## Build & Install
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY := notes
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
-LDFLAGS := -X github.com/dreikanter/notesctl/internal/cli.Version=$(VERSION)
+LDFLAGS := -X github.com/dreikanter/notes/internal/cli.Version=$(VERSION)
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/notes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# notesctl
+# notes
 
 A command-line tool for managing a plain-text note archive you own entirely.
 
@@ -15,12 +15,12 @@ The tool doesn't try to be a knowledge graph, a publishing platform, or a second
 2. **Retrieve** — find it again by ID, type, tag, or slug
 3. **Integrate** — pipe notes into other tools, scripts, and AI assistants
 
-Think of it as the storage layer that sits underneath your workflow, not the workflow itself. Obsidian and Logseq are rich GUIs built around their own vaults. notesctl is closer to a structured `~/notes` directory with a fast command-line interface on top — no plugins, no sync service, no lock-in. The files are yours; the CLI is optional convenience.
+Think of it as the storage layer that sits underneath your workflow, not the workflow itself. Obsidian and Logseq are rich GUIs built around their own vaults. notes is closer to a structured `~/notes` directory with a fast command-line interface on top — no plugins, no sync service, no lock-in. The files are yours; the CLI is optional convenience.
 
 ## Install
 
 ```sh
-go install github.com/dreikanter/notesctl/cmd/notes@latest
+go install github.com/dreikanter/notes/cmd/notes@latest
 ```
 
 Make sure `~/go/bin` is on your `PATH`:

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,9 +1,9 @@
 # Note frontmatter schema
 
 Reserved keys are the fields declared on `Frontmatter` in
-`github.com/dreikanter/notesctl/note`. Any key not listed below is
+`github.com/dreikanter/notes/note`. Any key not listed below is
 preserved verbatim on read/write (stored in `Frontmatter.Extra`)
-and ignored by notesctl itself.
+and ignored by notes itself.
 
 Downstream projects (notes-pub, notes-view) and users are free to
 introduce new bare keys. Collision risk with future reserved names
@@ -20,17 +20,17 @@ is called out in `CHANGELOG.md` when a new reserved key is added.
 - **Type:** string
 - **Semantics:** URL-safe identifier, canonical in frontmatter. The
   filename may carry a cached copy; on mismatch, frontmatter wins.
-- **Consumers:** notesctl (`new`, `update --sync-filename`),
+- **Consumers:** notes (`new`, `update --sync-filename`),
   notes-pub (URL path segment).
 
 ### type
 - **Type:** string
 - **Semantics:** note category. Any value is valid. A small set of
-  values (`todo`, `backlog`, `weekly`) trigger special notesctl
+  values (`todo`, `backlog`, `weekly`) trigger special notes
   behavior; see `note.HasSpecialBehavior`. The filename may
   carry a cached copy as a `.type` dot-suffix; on mismatch,
   frontmatter wins.
-- **Consumers:** notesctl (filters, rollover), notes-pub / notes-view
+- **Consumers:** notes (filters, rollover), notes-pub / notes-view
   (optional rendering).
 
 ### date
@@ -52,14 +52,14 @@ is called out in `CHANGELOG.md` when a new reserved key is added.
 - **Type:** list of strings
 - **Semantics:** free-form tags, matched case-sensitively. In-body
   `#hashtag` usage is a separate feature not governed by this field.
-- **Consumers:** notesctl (`tags`, filters), notes-pub (tag pages,
+- **Consumers:** notes (`tags`, filters), notes-pub (tag pages,
   feed), notes-view.
 
 ### aliases
 - **Type:** list of strings
 - **Semantics:** prior identifiers for the note — historical slugs,
   legacy IDs, or alternate names that should continue to resolve to
-  this note after a rename. notesctl itself does not yet consume this
+  this note after a rename. notes itself does not yet consume this
   field; it is reserved so downstream publishers can implement
   permalink redirects and rename-history handling without collision
   risk.
@@ -79,13 +79,13 @@ is called out in `CHANGELOG.md` when a new reserved key is added.
 
 ## Unreserved keys
 
-Any other top-level key is preserved untouched by notesctl. Nested
+Any other top-level key is preserved untouched by notes. Nested
 structures (mappings, sequences) are preserved intact.
 
 Duplicate top-level keys are rejected at the document level.
 Non-scalar keys are rejected. Anchors and aliases in the YAML
 tree are preserved inside `Extra` values as-is but are not
-specifically tested in notesctl; use at your own risk.
+specifically tested in notes; use at your own risk.
 
 ## Process
 

--- a/cmd/notes/main.go
+++ b/cmd/notes/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/dreikanter/notesctl/internal/cli"
+	"github.com/dreikanter/notes/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dreikanter/notesctl
+module github.com/dreikanter/notes
 
 go 1.25.8
 

--- a/internal/cli/annotate.go
+++ b/internal/cli/annotate.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/annotate_test.go
+++ b/internal/cli/annotate_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/cli/append.go
+++ b/internal/cli/append.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/new_todo.go
+++ b/internal/cli/new_todo.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/new_todo_test.go
+++ b/internal/cli/new_todo_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/resolve.go
+++ b/internal/cli/resolve.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/note/id_other.go
+++ b/note/id_other.go
@@ -4,7 +4,7 @@ package note
 
 // lockStoreRoot is a no-op on non-Unix platforms where syscall.Flock is not
 // available. Concurrent NextID calls are not serialized on these platforms;
-// the notesctl CLI is primarily used interactively on a single machine, so
+// the notes CLI is primarily used interactively on a single machine, so
 // races are unlikely in practice.
 func lockStoreRoot(_ string) (func(), error) {
 	return func() {}, nil

--- a/note/note.go
+++ b/note/note.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-// typesWithSpecialBehavior lists note types that trigger notesctl-specific
+// typesWithSpecialBehavior lists note types that trigger notes-specific
 // handling (e.g., daily rollover, weekly review conventions). Any string is a
 // valid `type` value; this list is a soft registry, not a validation gate.
 // It is unexported because external importers must not be able to mutate it
@@ -14,7 +14,7 @@ import (
 var typesWithSpecialBehavior = []string{"todo", "backlog", "weekly"}
 
 // SpecialBehaviorTypes returns a fresh copy of the soft registry of note
-// types with notesctl-specific handling. The returned slice may be freely
+// types with notes-specific handling. The returned slice may be freely
 // mutated without affecting the package-internal list.
 func SpecialBehaviorTypes() []string {
 	out := make([]string, len(typesWithSpecialBehavior))
@@ -22,7 +22,7 @@ func SpecialBehaviorTypes() []string {
 	return out
 }
 
-// HasSpecialBehavior reports whether s is a type with special notesctl behavior.
+// HasSpecialBehavior reports whether s is a type with special notes behavior.
 func HasSpecialBehavior(s string) bool {
 	for _, t := range typesWithSpecialBehavior {
 		if s == t {


### PR DESCRIPTION
## Summary

I want to use a name that's easy to type, and I don't care much about making it unique. All unique meaningful names are used anyway. It's a notes tool, so let's call it what it is.

- Update Go module path from `github.com/dreikanter/notesctl` to `github.com/dreikanter/notes` to match the renamed GitHub repo
- Refresh all internal imports, `Makefile` LDFLAGS, README/CLAUDE/SCHEMA wording, and a few in-code comments
- The CLI binary, command name, and `NOTES_PATH` env var are unchanged