### PR TITLE
Drop redundant 'version' word from --version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `notes --version` no longer prints a redundant `version v...`; the output is now `notes vX.Y.Z`.
+
 ### Changed
 
 - Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release ([#271]).

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,6 +30,7 @@ func init() {
 		}
 	}
 	rootCmd.Version = Version
+	rootCmd.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 	rootCmd.PersistentFlags().StringVar(&notesPath, "path", "", "path to notes store (default: $NOTES_PATH)")
 }
 


### PR DESCRIPTION
## Summary

- `notes --version` previously printed `notes version v...`, with a redundant `version v` because git tags use the `vX.Y.Z` form and Cobra's default version template adds its own `version` word.
- Override Cobra's version template to `{{.Name}} {{.Version}}`, so output is now `notes v...`.
- Keeps `Version` matching the canonical git tag / Go module version (also returned by `debug.ReadBuildInfo`), so the displayed string is consistent across local builds and `go install ...@vX.Y.Z` builds.

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only