### PR TITLE
Add tags rename command with unicode hashtag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,20 @@
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- `notes --version` no longer prints a redundant `version v...`; the output is now `notes vX.Y.Z`.
+- `notes tags rename <old> <new>` renames a tag across the store, rewriting frontmatter `tags:` lists and body `#hashtag` tokens. Matches case-insensitively; writes the new name literally. Supports `--dry-run`.
+- `notes tags list` (explicit alias for `notes tags`).
 
 ### Changed
 
+- Hashtag tokens now accept unicode letters and digits in addition to `[A-Za-z0-9_-]`. Adjacent-prose detection is also unicode-aware: `café#bar` no longer extracts `bar`. Stores using non-ASCII text in notes may see `notes tags` and `notes ls --tag` results shift accordingly.
+- A body-only tag becomes an explicit frontmatter tag after `notes tags rename` rewrites a note (consistent with how `notes update --tag` already behaves).
 - Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release ([#271]).
+
+### Fixed
+
+- `notes --version` no longer prints a redundant `version v...`; the output is now `notes vX.Y.Z`.
 
 [#271]: https://github.com/dreikanter/notes/pull/271
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ notes update 8823 --private
 
 # List all tags (frontmatter + body hashtags)
 notes tags
+notes tags list                     # explicit alias
+
+# Rename a tag across the whole store
+notes tags rename work personal
+notes tags rename --dry-run work personal
 
 # Print the effective runtime configuration (resolved store path, defaults, env vars)
 notes config

--- a/internal/cli/tags.go
+++ b/internal/cli/tags.go
@@ -59,17 +59,24 @@ var tagsRenameCmd = &cobra.Command{
 		n := len(res.ModifiedPaths)
 		switch {
 		case renameErr != nil:
-			fmt.Fprintf(errOut, "partial: renamed in %d notes before error\n", n)
+			fmt.Fprintf(errOut, "partial: renamed in %s before error\n", pluralNotes(n))
 			return renameErr
 		case n == 0:
 			fmt.Fprintf(errOut, "no notes contained tag %q\n", oldTag)
 		case dryRun:
-			fmt.Fprintf(errOut, "would rename %q → %q in %d notes\n", oldTag, newTag, n)
+			fmt.Fprintf(errOut, "would rename %q → %q in %s\n", oldTag, newTag, pluralNotes(n))
 		default:
-			fmt.Fprintf(errOut, "renamed %q → %q in %d notes\n", oldTag, newTag, n)
+			fmt.Fprintf(errOut, "renamed %q → %q in %s\n", oldTag, newTag, pluralNotes(n))
 		}
 		return nil
 	},
+}
+
+func pluralNotes(n int) string {
+	if n == 1 {
+		return "1 note"
+	}
+	return fmt.Sprintf("%d notes", n)
 }
 
 func runTagsList(cmd *cobra.Command) error {

--- a/internal/cli/tags.go
+++ b/internal/cli/tags.go
@@ -35,10 +35,13 @@ var tagsRenameCmd = &cobra.Command{
 		newTag := args[1]
 
 		if oldTag == "" {
-			return fmt.Errorf("old tag must be non-empty")
+			return fmt.Errorf("old tag is empty")
+		}
+		if newTag == "" {
+			return fmt.Errorf("new tag is empty")
 		}
 		if err := note.ValidateTag(newTag); err != nil {
-			return err
+			return fmt.Errorf("new tag: %w", err)
 		}
 
 		dryRun, _ := cmd.Flags().GetBool("dry-run")

--- a/internal/cli/tags.go
+++ b/internal/cli/tags.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/dreikanter/notes/note"
 	"github.com/spf13/cobra"
 )
 
@@ -12,33 +13,95 @@ var tagsCmd = &cobra.Command{
 	Short: "List all tags from frontmatter and body hashtags",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		return runTagsList(cmd)
+	},
+}
+
+var tagsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all tags from frontmatter and body hashtags",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runTagsList(cmd)
+	},
+}
+
+var tagsRenameCmd = &cobra.Command{
+	Use:   "rename <old> <new>",
+	Short: "Rename a tag across the store (frontmatter and body hashtags)",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		oldTag := args[0]
+		newTag := args[1]
+
+		if oldTag == "" {
+			return fmt.Errorf("old tag must be non-empty")
+		}
+		if err := note.ValidateTag(newTag); err != nil {
+			return err
+		}
+
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
 		store, err := notesStore()
 		if err != nil {
 			return err
 		}
-		entries, err := store.All()
-		if err != nil {
-			return err
-		}
-		set := make(map[string]struct{})
-		for _, e := range entries {
-			for _, t := range e.Meta.Tags {
-				set[t] = struct{}{}
-			}
-		}
-		tags := make([]string, 0, len(set))
-		for t := range set {
-			tags = append(tags, t)
-		}
-		sort.Strings(tags)
+
+		res, renameErr := note.RenameTag(store, oldTag, newTag, note.RenameOpts{DryRun: dryRun})
+
 		out := cmd.OutOrStdout()
-		for _, t := range tags {
-			fmt.Fprintln(out, t)
+		errOut := cmd.ErrOrStderr()
+		for _, p := range res.ModifiedPaths {
+			fmt.Fprintln(out, p)
+		}
+
+		n := len(res.ModifiedPaths)
+		switch {
+		case renameErr != nil:
+			fmt.Fprintf(errOut, "partial: renamed in %d notes before error\n", n)
+			return renameErr
+		case n == 0:
+			fmt.Fprintf(errOut, "no notes contained tag %q\n", oldTag)
+		case dryRun:
+			fmt.Fprintf(errOut, "would rename %q → %q in %d notes\n", oldTag, newTag, n)
+		default:
+			fmt.Fprintf(errOut, "renamed %q → %q in %d notes\n", oldTag, newTag, n)
 		}
 		return nil
 	},
 }
 
+func runTagsList(cmd *cobra.Command) error {
+	store, err := notesStore()
+	if err != nil {
+		return err
+	}
+	entries, err := store.All()
+	if err != nil {
+		return err
+	}
+	set := make(map[string]struct{})
+	for _, e := range entries {
+		for _, t := range e.Meta.Tags {
+			set[t] = struct{}{}
+		}
+	}
+	tags := make([]string, 0, len(set))
+	for t := range set {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags)
+	out := cmd.OutOrStdout()
+	for _, t := range tags {
+		fmt.Fprintln(out, t)
+	}
+	return nil
+}
+
 func init() {
+	tagsRenameCmd.Flags().Bool("dry-run", false, "print modifications without writing")
+	tagsCmd.AddCommand(tagsListCmd)
+	tagsCmd.AddCommand(tagsRenameCmd)
 	rootCmd.AddCommand(tagsCmd)
 }

--- a/internal/cli/tags_test.go
+++ b/internal/cli/tags_test.go
@@ -11,8 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// resetTagsFlags clears subcommand flag state that cobra retains between
+// rootCmd.Execute() invocations, so independent tests don't leak settings
+// (e.g. --dry-run) into each other.
+func resetTagsFlags() {
+	_ = tagsRenameCmd.Flags().Set("dry-run", "false")
+}
+
 func runTags(t *testing.T, root string, args ...string) (string, error) {
 	t.Helper()
+	resetTagsFlags()
 
 	buf := new(bytes.Buffer)
 	rootCmd.SetOut(buf)
@@ -25,6 +33,7 @@ func runTags(t *testing.T, root string, args ...string) (string, error) {
 
 func runTagsSplit(t *testing.T, root string, args ...string) (string, string, error) {
 	t.Helper()
+	resetTagsFlags()
 
 	outBuf := new(bytes.Buffer)
 	errBuf := new(bytes.Buffer)
@@ -112,13 +121,25 @@ func TestTagsRenameHappyPath(t *testing.T) {
 	stdout, stderr, err := runTagsSplit(t, root, "rename", "work", "personal")
 	require.NoError(t, err)
 	assert.Equal(t, path+"\n", stdout)
-	assert.Contains(t, stderr, "renamed")
-	assert.Contains(t, stderr, "in 1 note\n")
+	assert.Equal(t, "renamed \"work\" → \"personal\" in 1 note\n", stderr)
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
 	assert.Contains(t, string(got), "tags:\n    - personal")
 	assert.Contains(t, string(got), "body #personal here")
+}
+
+func TestTagsRenameHappyPathPlural(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [work]\n---\n\na\n")
+	writeTagsTestNote(t, root, "2026/01/20260102_2.md",
+		"---\ntags: [work]\n---\n\nb\n")
+
+	_, stderr, err := runTagsSplit(t, root, "rename", "work", "personal")
+	require.NoError(t, err)
+	assert.Equal(t, "renamed \"work\" → \"personal\" in 2 notes\n", stderr)
 }
 
 func TestTagsRenameDryRun(t *testing.T) {
@@ -131,7 +152,7 @@ func TestTagsRenameDryRun(t *testing.T) {
 	stdout, stderr, err := runTagsSplit(t, root, "rename", "--dry-run", "work", "personal")
 	require.NoError(t, err)
 	assert.Equal(t, path+"\n", stdout)
-	assert.Contains(t, stderr, "would rename")
+	assert.Equal(t, "would rename \"work\" → \"personal\" in 1 note\n", stderr)
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)
@@ -167,5 +188,41 @@ func TestTagsRenameNoMatches(t *testing.T) {
 	stdout, stderr, err := runTagsSplit(t, root, "rename", "nope", "x")
 	require.NoError(t, err)
 	assert.Empty(t, strings.TrimSpace(stdout))
-	assert.Contains(t, stderr, `no notes contained tag "nope"`)
+	assert.Equal(t, "no notes contained tag \"nope\"\n", stderr)
+}
+
+func TestTagsRenameUnicode(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	path := filepath.Join(root, "2026", "01", "20260101_1.md")
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [café]\n---\n\ndrink #café please\n")
+
+	stdout, stderr, err := runTagsSplit(t, root, "rename", "café", "latte")
+	require.NoError(t, err)
+	assert.Equal(t, path+"\n", stdout)
+	assert.Equal(t, "renamed \"café\" → \"latte\" in 1 note\n", stderr)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "tags:\n    - latte")
+	assert.Contains(t, string(got), "drink #latte please")
+}
+
+func TestTagsRenameCaseOnly(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	path := filepath.Join(root, "2026", "01", "20260101_1.md")
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [work]\n---\n\nbody #work here\n")
+
+	stdout, stderr, err := runTagsSplit(t, root, "rename", "work", "WORK")
+	require.NoError(t, err)
+	assert.Equal(t, path+"\n", stdout)
+	assert.Equal(t, "renamed \"work\" → \"WORK\" in 1 note\n", stderr)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "tags:\n    - WORK")
+	assert.Contains(t, string(got), "body #WORK here")
 }

--- a/internal/cli/tags_test.go
+++ b/internal/cli/tags_test.go
@@ -113,7 +113,7 @@ func TestTagsRenameHappyPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, path+"\n", stdout)
 	assert.Contains(t, stderr, "renamed")
-	assert.Contains(t, stderr, "in 1 notes")
+	assert.Contains(t, stderr, "in 1 note\n")
 
 	got, err := os.ReadFile(path)
 	require.NoError(t, err)

--- a/internal/cli/tags_test.go
+++ b/internal/cli/tags_test.go
@@ -23,6 +23,24 @@ func runTags(t *testing.T, root string, args ...string) (string, error) {
 	return strings.TrimSpace(buf.String()), err
 }
 
+func runTagsSplit(t *testing.T, root string, args ...string) (string, string, error) {
+	t.Helper()
+
+	outBuf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(outBuf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs(append([]string{"tags", "--path", root}, args...))
+
+	err := rootCmd.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+func writeIDJSON(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "id.json"), []byte(`{"last_id":0}`), 0o644))
+}
+
 func writeTagsTestNote(t *testing.T, root, rel, content string) {
 	t.Helper()
 	full := filepath.Join(root, rel)
@@ -69,4 +87,85 @@ func TestTagsIgnoresCodeBlocks(t *testing.T) {
 	assert.NotContains(t, out, "should-not-appear")
 	assert.Contains(t, out, "real")
 	assert.Contains(t, out, "done")
+}
+
+func TestTagsListSubcommandSameAsTags(t *testing.T) {
+	root := t.TempDir()
+	writeTagsTestNote(t, root, "2026/01/20260101_1001.md",
+		"---\ntags: [work, planning]\n---\n\nhere is #coffee\n")
+
+	bare, err := runTags(t, root)
+	require.NoError(t, err)
+	listed, err := runTags(t, root, "list")
+	require.NoError(t, err)
+	assert.Equal(t, bare, listed)
+	assert.Equal(t, []string{"coffee", "planning", "work"}, strings.Split(bare, "\n"))
+}
+
+func TestTagsRenameHappyPath(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	path := filepath.Join(root, "2026", "01", "20260101_1.md")
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [work]\n---\n\nbody #work here\n")
+
+	stdout, stderr, err := runTagsSplit(t, root, "rename", "work", "personal")
+	require.NoError(t, err)
+	assert.Equal(t, path+"\n", stdout)
+	assert.Contains(t, stderr, "renamed")
+	assert.Contains(t, stderr, "in 1 notes")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "tags:\n    - personal")
+	assert.Contains(t, string(got), "body #personal here")
+}
+
+func TestTagsRenameDryRun(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	path := filepath.Join(root, "2026", "01", "20260101_1.md")
+	content := "---\ntags: [work]\n---\n\nbody #work here\n"
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md", content)
+
+	stdout, stderr, err := runTagsSplit(t, root, "rename", "--dry-run", "work", "personal")
+	require.NoError(t, err)
+	assert.Equal(t, path+"\n", stdout)
+	assert.Contains(t, stderr, "would rename")
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got), "file should be untouched in dry-run")
+}
+
+func TestTagsRenameEmptyArgsFail(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+
+	_, _, err := runTagsSplit(t, root, "rename", "", "new")
+	require.Error(t, err)
+
+	_, _, err = runTagsSplit(t, root, "rename", "old", "")
+	require.Error(t, err)
+}
+
+func TestTagsRenameInvalidNewTag(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+
+	_, _, err := runTagsSplit(t, root, "rename", "old", "has space")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid tag character")
+}
+
+func TestTagsRenameNoMatches(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [other]\n---\n\nbody\n")
+
+	stdout, stderr, err := runTagsSplit(t, root, "rename", "nope", "x")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(stdout))
+	assert.Contains(t, stderr, `no notes contained tag "nope"`)
 }

--- a/note/rename.go
+++ b/note/rename.go
@@ -37,12 +37,13 @@ func RenameTag(store *OSStore, oldTag, newTag string, opts RenameOpts) (RenameRe
 		return RenameResult{}, err
 	}
 
+	replacement := []byte("#" + newTag)
+	replaceFn := func(_ []byte) []byte { return replacement }
+
 	var result RenameResult
 	for _, entry := range entries {
 		newTags, tagsChanged := rewriteMetaTags(entry.Meta.Tags, lowerOld, newTag)
-		newBody, bodyN := ReplaceBodyHashtags([]byte(entry.Body), lowerOld, func(_ []byte) []byte {
-			return []byte("#" + newTag)
-		})
+		newBody, bodyN := ReplaceBodyHashtags([]byte(entry.Body), lowerOld, replaceFn)
 
 		if !tagsChanged && bodyN == 0 {
 			continue

--- a/note/rename.go
+++ b/note/rename.go
@@ -20,16 +20,15 @@ type RenameResult struct {
 // RenameTag rewrites every occurrence of oldTag (matched case-insensitively)
 // across the store, both in frontmatter "tags:" lists and in body "#hashtag"
 // tokens, replacing it with newTag written literally. The store root is
-// locked for the duration. On mid-run failure, RenameTag returns the error
-// together with the partial path list of notes already written.
+// locked for the duration — including dry-run, so the previewed path list
+// reflects a consistent snapshot. On mid-run failure, RenameTag returns the
+// error together with the partial path list of notes already written.
 func RenameTag(store *OSStore, oldTag, newTag string, opts RenameOpts) (RenameResult, error) {
-	if !opts.DryRun {
-		unlock, err := lockStoreRoot(store.Root())
-		if err != nil {
-			return RenameResult{}, err
-		}
-		defer unlock()
+	unlock, err := lockStoreRoot(store.Root())
+	if err != nil {
+		return RenameResult{}, err
 	}
+	defer unlock()
 
 	lowerOld := strings.ToLower(oldTag)
 

--- a/note/rename.go
+++ b/note/rename.go
@@ -1,0 +1,95 @@
+package note
+
+import (
+	"strings"
+)
+
+// RenameOpts configures RenameTag.
+type RenameOpts struct {
+	// DryRun reports the modified paths without writing.
+	DryRun bool
+}
+
+// RenameResult is the outcome of a RenameTag call.
+type RenameResult struct {
+	// ModifiedPaths lists the absolute path of every note that was (or
+	// would be, in dry-run mode) modified, in newest-first order.
+	ModifiedPaths []string
+}
+
+// RenameTag rewrites every occurrence of oldTag (matched case-insensitively)
+// across the store, both in frontmatter "tags:" lists and in body "#hashtag"
+// tokens, replacing it with newTag written literally. The store root is
+// locked for the duration. On mid-run failure, RenameTag returns the error
+// together with the partial path list of notes already written.
+func RenameTag(store *OSStore, oldTag, newTag string, opts RenameOpts) (RenameResult, error) {
+	if !opts.DryRun {
+		unlock, err := lockStoreRoot(store.Root())
+		if err != nil {
+			return RenameResult{}, err
+		}
+		defer unlock()
+	}
+
+	lowerOld := strings.ToLower(oldTag)
+
+	entries, err := store.All(WithTag(oldTag))
+	if err != nil {
+		return RenameResult{}, err
+	}
+
+	var result RenameResult
+	for _, entry := range entries {
+		newTags, tagsChanged := rewriteMetaTags(entry.Meta.Tags, lowerOld, newTag)
+		newBody, bodyN := ReplaceBodyHashtags([]byte(entry.Body), lowerOld, func(_ []byte) []byte {
+			return []byte("#" + newTag)
+		})
+
+		if !tagsChanged && bodyN == 0 {
+			continue
+		}
+
+		entry.Meta.Tags = newTags
+		entry.Body = string(newBody)
+
+		if opts.DryRun {
+			result.ModifiedPaths = append(result.ModifiedPaths, store.AbsPath(entry))
+			continue
+		}
+
+		saved, err := store.Put(entry)
+		if err != nil {
+			return result, err
+		}
+		result.ModifiedPaths = append(result.ModifiedPaths, store.AbsPath(saved))
+	}
+
+	return result, nil
+}
+
+// rewriteMetaTags returns the rewritten tag list and whether any change
+// occurred. Every case-variant of lowerOld is dropped; if at least one was
+// present, newTag is appended and any pre-existing case variant of newTag
+// is dropped first so the user-typed surface form wins.
+func rewriteMetaTags(tags []string, lowerOld, newTag string) ([]string, bool) {
+	matched := false
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if strings.ToLower(t) == lowerOld {
+			matched = true
+			continue
+		}
+		out = append(out, t)
+	}
+	if !matched {
+		return tags, false
+	}
+	lowerNew := strings.ToLower(newTag)
+	filtered := out[:0]
+	for _, t := range out {
+		if strings.ToLower(t) != lowerNew {
+			filtered = append(filtered, t)
+		}
+	}
+	return append(filtered, newTag), true
+}

--- a/note/rename_test.go
+++ b/note/rename_test.go
@@ -59,17 +59,18 @@ func TestRenameTag_BodyOnly(t *testing.T) {
 	s := newOSTestStore(t)
 	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
 
-	putForRename(t, s, day, nil, "see #work please\n")
+	// Body has the renamed tag plus an unrelated hashtag. The unrelated
+	// hashtag is promoted to frontmatter on write (documented behavior).
+	putForRename(t, s, day, nil, "see #work and #foo please\n")
 
 	res, err := RenameTag(s, "work", "personal", RenameOpts{})
 	require.NoError(t, err)
 	require.Len(t, res.ModifiedPaths, 1)
 
 	body := readBody(t, res.ModifiedPaths[0])
-	assert.Equal(t, "see #personal please\n", body)
+	assert.Equal(t, "see #personal and #foo please\n", body)
 	tags := readTags(t, res.ModifiedPaths[0])
-	// body-only tag becomes an explicit frontmatter tag after rewrite.
-	assert.Contains(t, tags, "personal")
+	assert.ElementsMatch(t, []string{"foo", "personal"}, tags)
 }
 
 func TestRenameTag_FrontmatterAndBody(t *testing.T) {

--- a/note/rename_test.go
+++ b/note/rename_test.go
@@ -45,7 +45,7 @@ func TestRenameTag_FrontmatterOnly(t *testing.T) {
 	s := newOSTestStore(t)
 	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
 
-	e := putForRename(t, s, day, []string{"work", "other"}, "no body tag\n")
+	putForRename(t, s, day, []string{"work", "other"}, "no body tag\n")
 
 	res, err := RenameTag(s, "work", "personal", RenameOpts{})
 	require.NoError(t, err)
@@ -53,7 +53,6 @@ func TestRenameTag_FrontmatterOnly(t *testing.T) {
 
 	tags := readTags(t, res.ModifiedPaths[0])
 	assert.ElementsMatch(t, []string{"other", "personal"}, tags)
-	_ = e
 }
 
 func TestRenameTag_BodyOnly(t *testing.T) {

--- a/note/rename_test.go
+++ b/note/rename_test.go
@@ -1,0 +1,307 @@
+package note
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func putForRename(t *testing.T, s *OSStore, day time.Time, tags []string, body string) Entry {
+	t.Helper()
+	entry, err := s.Put(Entry{
+		Meta: Meta{Tags: tags, CreatedAt: day},
+		Body: body,
+	})
+	require.NoError(t, err)
+	return entry
+}
+
+func readBody(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	_, body, err := ParseNote(data)
+	require.NoError(t, err)
+	return string(body)
+}
+
+func readTags(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	fm, _, err := ParseNote(data)
+	require.NoError(t, err)
+	return fm.Tags
+}
+
+func TestRenameTag_FrontmatterOnly(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	e := putForRename(t, s, day, []string{"work", "other"}, "no body tag\n")
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	tags := readTags(t, res.ModifiedPaths[0])
+	assert.ElementsMatch(t, []string{"other", "personal"}, tags)
+	_ = e
+}
+
+func TestRenameTag_BodyOnly(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, nil, "see #work please\n")
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	body := readBody(t, res.ModifiedPaths[0])
+	assert.Equal(t, "see #personal please\n", body)
+	tags := readTags(t, res.ModifiedPaths[0])
+	// body-only tag becomes an explicit frontmatter tag after rewrite.
+	assert.Contains(t, tags, "personal")
+}
+
+func TestRenameTag_FrontmatterAndBody(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"work"}, "ref #work here\n")
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	body := readBody(t, res.ModifiedPaths[0])
+	assert.Equal(t, "ref #personal here\n", body)
+	tags := readTags(t, res.ModifiedPaths[0])
+	assert.Equal(t, []string{"personal"}, tags)
+}
+
+func TestRenameTag_NewTagWinsOverExistingCaseVariant(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"Personal", "work"}, "body\n")
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	tags := readTags(t, res.ModifiedPaths[0])
+	assert.Equal(t, []string{"personal"}, tags)
+}
+
+func TestRenameTag_BystanderUntouched(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	bystander := putForRename(t, s, day, []string{"Personal"}, "no work here\n")
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, res.ModifiedPaths)
+
+	tags := readTags(t, s.AbsPath(bystander))
+	assert.Equal(t, []string{"Personal"}, tags)
+}
+
+func TestRenameTag_BothFormsPresent(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"work", "personal"}, "body\n")
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	tags := readTags(t, res.ModifiedPaths[0])
+	assert.Equal(t, []string{"personal"}, tags)
+}
+
+func TestRenameTag_CaseOnlyRename(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"work"}, "ref #work\n")
+
+	res, err := RenameTag(s, "work", "WORK", RenameOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	tags := readTags(t, res.ModifiedPaths[0])
+	assert.Equal(t, []string{"WORK"}, tags)
+	body := readBody(t, res.ModifiedPaths[0])
+	assert.Equal(t, "ref #WORK\n", body)
+}
+
+func TestRenameTag_MixedCaseAcrossNotes(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"Work"}, "a\n")
+	putForRename(t, s, day, []string{"WORK"}, "b\n")
+	putForRename(t, s, day, []string{"work"}, "c\n")
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 3)
+
+	for _, p := range res.ModifiedPaths {
+		assert.Equal(t, []string{"personal"}, readTags(t, p))
+	}
+}
+
+func TestRenameTag_ZeroMatches(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"other"}, "no tag here\n")
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, res.ModifiedPaths)
+}
+
+func TestRenameTag_DryRun(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	e := putForRename(t, s, day, []string{"work"}, "ref #work\n")
+	originalInfo, err := os.Stat(s.AbsPath(e))
+	require.NoError(t, err)
+	originalMtime := originalInfo.ModTime()
+
+	// Ensure a real mtime difference would be observable if we wrote.
+	time.Sleep(10 * time.Millisecond)
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{DryRun: true})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	info, err := os.Stat(s.AbsPath(e))
+	require.NoError(t, err)
+	assert.True(t, info.ModTime().Equal(originalMtime), "file mtime should be unchanged in dry-run")
+
+	tags := readTags(t, s.AbsPath(e))
+	assert.Equal(t, []string{"work"}, tags)
+	body := readBody(t, s.AbsPath(e))
+	assert.Equal(t, "ref #work\n", body)
+}
+
+func TestRenameTag_PartialFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem-based failure injection is Unix-only")
+	}
+	s := newOSTestStore(t)
+	d1 := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	d2 := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+
+	e1 := putForRename(t, s, d1, []string{"work"}, "a\n")
+	e2 := putForRename(t, s, d2, []string{"work"}, "b\n")
+
+	// store.All returns newest-first, so e2 comes first. Block writes to
+	// e1's path by replacing its .tmp target with a directory: WriteAtomic
+	// writes "<path>.tmp" first, then renames, so a directory at that path
+	// causes the write to fail with EISDIR. This works regardless of
+	// process uid (chmod is bypassed for root, mkdir collisions are not).
+	first := s.AbsPath(e2)
+	second := s.AbsPath(e1)
+	require.NotEqual(t, first, second)
+
+	blocker := second + ".tmp"
+	require.NoError(t, os.MkdirAll(blocker, 0o755))
+	defer os.RemoveAll(blocker)
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.Error(t, err)
+
+	require.NoError(t, os.RemoveAll(blocker))
+	assert.Equal(t, []string{"personal"}, readTags(t, first))
+	assert.Equal(t, []string{"work"}, readTags(t, second))
+
+	assert.Equal(t, []string{first}, res.ModifiedPaths)
+}
+
+func TestRenameTag_BodyTagInsideCodeFenceIsNoop(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	body := "before\n```\n#work hidden\n```\nafter\n"
+	e := putForRename(t, s, day, nil, body)
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, res.ModifiedPaths)
+
+	// File unchanged: still has #work in the fence and no frontmatter tags.
+	got := readBody(t, s.AbsPath(e))
+	assert.Equal(t, body, got)
+}
+
+func TestRenameTag_URLAndHeadingGuards(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	body := "See [docs](https://example.com/#work) and #work and\n# work\nend\n"
+	putForRename(t, s, day, nil, body)
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	got := readBody(t, res.ModifiedPaths[0])
+	want := "See [docs](https://example.com/#work) and #personal and\n# work\nend\n"
+	assert.Equal(t, want, got)
+}
+
+func TestRenameTag_ValidateTagRejectsInvalid(t *testing.T) {
+	// Sanity check that ValidateTag catches bad new-tag inputs the CLI
+	// will use for early validation.
+	cases := []string{"", "has space", "a/b", "tag."}
+	for _, s := range cases {
+		err := ValidateTag(s)
+		assert.Error(t, err, s)
+	}
+}
+
+func TestRenameTag_OrderIsNewestFirst(t *testing.T) {
+	s := newOSTestStore(t)
+
+	// Three days, each gets one note with tag work.
+	d1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	d2 := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	d3 := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+	putForRename(t, s, d1, []string{"work"}, "a\n")
+	putForRename(t, s, d2, []string{"work"}, "b\n")
+	putForRename(t, s, d3, []string{"work"}, "c\n")
+
+	res, err := RenameTag(s, "work", "personal", RenameOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 3)
+
+	// Paths should be ordered newest-first (d3 then d2 then d1).
+	got := make([]string, len(res.ModifiedPaths))
+	for i, p := range res.ModifiedPaths {
+		got[i] = filepath.Base(p)
+	}
+	// Date prefix order: 20260103 > 20260102 > 20260101
+	sortedDesc := append([]string(nil), got...)
+	sort.Sort(sort.Reverse(sort.StringSlice(sortedDesc)))
+	assert.Equal(t, sortedDesc, got, "expected newest-first order")
+	for _, p := range res.ModifiedPaths {
+		assert.True(t, strings.HasSuffix(p, ".md"))
+	}
+}

--- a/note/tags.go
+++ b/note/tags.go
@@ -2,9 +2,59 @@ package note
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
+
+// IsTagRune reports whether r is allowed inside a tag token: any unicode
+// letter, any unicode digit, '_', or '-'.
+func IsTagRune(r rune) bool {
+	if r == '_' || r == '-' {
+		return true
+	}
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// ValidateTag reports whether s is a non-empty string of tag runes.
+// Returns nil on valid input; an error describing the offending rune
+// otherwise.
+func ValidateTag(s string) error {
+	if s == "" {
+		return fmt.Errorf("tag is empty")
+	}
+	for _, r := range s {
+		if !IsTagRune(r) {
+			return fmt.Errorf("invalid tag character %q in %q", r, s)
+		}
+	}
+	return nil
+}
+
+// isWordRune reports whether r is a "word" rune: unicode letter, unicode
+// digit, or '_'. Used to detect that a '#' is attached to prose.
+func isWordRune(r rune) bool {
+	if r == '_' {
+		return true
+	}
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// isHashtagLeadingRune reports whether r may legally precede a '#' that
+// starts a hashtag. Excludes word runes (any unicode letter/digit/'_')
+// and URL-path bytes ('/', ':', '.', '?', '=', '&', '~', '#').
+func isHashtagLeadingRune(r rune) bool {
+	if isWordRune(r) {
+		return false
+	}
+	switch r {
+	case '/', ':', '.', '?', '=', '&', '~', '#':
+		return false
+	}
+	return true
+}
 
 // ExtractHashtags scans body text and returns hashtag tokens (without the
 // leading '#'), preserving source order and including duplicates. Rules:
@@ -15,30 +65,91 @@ import (
 //     are not recognised.
 //   - Inline backtick spans on a single line are skipped. An unclosed
 //     backtick suppresses hashtags for the remainder of its line.
-//   - A '#' preceded by a word byte ([A-Za-z0-9_]) or a URL-path byte
-//     (`/`, `:`, `.`, `?`, `=`, `&`, `~`, `#`) is not a tag. This prevents
-//     matches inside URLs (`example.com/#anchor`) and inline chains
-//     (`#one#two`). The check is byte-level, so hashtags adjacent to
-//     non-ASCII prose (e.g. `café#bar`) may still be extracted.
-//   - Tag characters are [A-Za-z0-9_-]; other bytes terminate a tag. A bare
-//     '#' with no following tag byte produces no output. A tag immediately
-//     followed by another '#' (e.g. `#one#two`) is rejected.
+//   - A '#' preceded by a word rune (any unicode letter/digit/'_') or a
+//     URL-path byte (`/`, `:`, `.`, `?`, `=`, `&`, `~`, `#`) is not a tag.
+//     This prevents matches inside URLs (`example.com/#anchor`), inline
+//     chains (`#one#two`), and adjacency to prose in any script
+//     (`café#bar`, `работа#tag`).
+//   - Tag characters are any unicode letter, any unicode digit, '_', or
+//     '-'; other runes terminate a tag. A bare '#' with no following tag
+//     rune produces no output. A tag immediately followed by another '#'
+//     (e.g. `#one#two`) is rejected.
 func ExtractHashtags(body []byte) []string {
 	var out []string
+	scanBodyAbs(body, func(_ int, line []byte, j, k int) {
+		out = append(out, string(line[j+1:k]))
+	})
+	return out
+}
+
+// ReplaceBodyHashtags walks body using the same rules as ExtractHashtags.
+// For every hashtag token whose lowercased value equals lowerMatch, the
+// "#token" span (the leading '#' plus the token bytes) is replaced with
+// the bytes returned by replace(token); token is the original byte slice
+// of the hashtag without '#'. Returns the rewritten body and the number
+// of replacements. body is returned unchanged (and n=0) if no
+// replacements occur.
+func ReplaceBodyHashtags(body []byte, lowerMatch string, replace func(token []byte) []byte) (out []byte, n int) {
+	type span struct {
+		start int
+		end   int
+		token []byte
+	}
+	var spans []span
+
+	scanBodyAbs(body, func(absLineStart int, line []byte, j, k int) {
+		token := line[j+1 : k]
+		if strings.ToLower(string(token)) != lowerMatch {
+			return
+		}
+		spans = append(spans, span{
+			start: absLineStart + j,
+			end:   absLineStart + k,
+			token: token,
+		})
+	})
+
+	if len(spans) == 0 {
+		return body, 0
+	}
+
+	var buf bytes.Buffer
+	buf.Grow(len(body))
+	last := 0
+	for _, sp := range spans {
+		buf.Write(body[last:sp.start])
+		buf.Write(replace(sp.token))
+		last = sp.end
+	}
+	buf.Write(body[last:])
+	return buf.Bytes(), len(spans)
+}
+
+// scanBodyAbs invokes fn for every hashtag token found in body. line is
+// the current line's bytes (without trailing CR/LF); j is the index of
+// the '#' within line and k is the exclusive end of the token. The
+// absLineStart parameter is the absolute byte offset of the line's start
+// within body, so callers can translate (j, k) into absolute body
+// offsets when rewriting.
+func scanBodyAbs(body []byte, fn func(absLineStart int, line []byte, j, k int)) {
 	inFence := false
 	fence := []byte("```")
 
-	for len(body) > 0 {
-		nl := bytes.IndexByte(body, '\n')
+	pos := 0
+	for pos < len(body) {
+		lineStart := pos
+		nl := bytes.IndexByte(body[pos:], '\n')
 		var line []byte
 		if nl < 0 {
-			line = body
-			body = nil
+			line = body[pos:]
+			pos = len(body)
 		} else {
-			line = body[:nl]
-			body = body[nl+1:]
+			line = body[pos : pos+nl]
+			pos = pos + nl + 1
 		}
-		line = bytes.TrimRight(line, "\r")
+		if n := len(line); n > 0 && line[n-1] == '\r' {
+			line = line[:n-1]
+		}
 
 		trim := 0
 		for trim < len(line) && (line[trim] == ' ' || line[trim] == '\t') {
@@ -53,6 +164,7 @@ func ExtractHashtags(body []byte) []string {
 			continue
 		}
 
+		// Heading detection: leading '#' run followed by space/tab/EOL.
 		if trim < len(line) && line[trim] == '#' {
 			k := trim
 			for k < len(line) && line[k] == '#' {
@@ -63,54 +175,56 @@ func ExtractHashtags(body []byte) []string {
 			}
 		}
 
-		inInline := false
-		for j := 0; j < len(line); j++ {
-			c := line[j]
-			if c == '`' {
-				inInline = !inInline
+		scanLineHashtags(line, lineStart, fn)
+	}
+}
+
+// scanLineHashtags scans a single line (already stripped of CR/LF) for
+// hashtag tokens, honoring inline-backtick spans and the leading-rune
+// rule. It invokes fn for every accepted token.
+func scanLineHashtags(line []byte, absLineStart int, fn func(absLineStart int, line []byte, j, k int)) {
+	inInline := false
+	j := 0
+	for j < len(line) {
+		c := line[j]
+		if c == '`' {
+			inInline = !inInline
+			j++
+			continue
+		}
+		if c != '#' || inInline {
+			j++
+			continue
+		}
+		// Check the rune immediately preceding '#'.
+		if j > 0 {
+			r, _ := utf8.DecodeLastRune(line[:j])
+			if !isHashtagLeadingRune(r) {
+				j++
 				continue
 			}
-			if c != '#' || inInline {
-				continue
+		}
+		// Consume tag runes starting at j+1.
+		k := j + 1
+		for k < len(line) {
+			r, size := utf8.DecodeRune(line[k:])
+			if r == utf8.RuneError && size <= 1 {
+				break
 			}
-			if j > 0 && !isHashtagLeadingByte(line[j-1]) {
-				continue
+			if !IsTagRune(r) {
+				break
 			}
-			k := j + 1
-			for k < len(line) && isTagByte(line[k]) {
-				k++
-			}
-			if k > j+1 && (k == len(line) || line[k] != '#') {
-				out = append(out, string(line[j+1:k]))
-			}
-			j = k - 1
+			k += size
+		}
+		if k > j+1 && (k == len(line) || line[k] != '#') {
+			fn(absLineStart, line, j, k)
+		}
+		if k > j+1 {
+			j = k
+		} else {
+			j++
 		}
 	}
-	return out
-}
-
-func isTagByte(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') || c == '_' || c == '-'
-}
-
-func isWordByte(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-		(c >= '0' && c <= '9') || c == '_'
-}
-
-// isHashtagLeadingByte reports whether c may legally precede a '#' that
-// starts a hashtag. Word bytes (so `foo#bar` is not a tag) and URL-path
-// bytes (so `example.com/#anchor` is not a tag) are excluded.
-func isHashtagLeadingByte(c byte) bool {
-	if isWordByte(c) {
-		return false
-	}
-	switch c {
-	case '/', ':', '.', '?', '=', '&', '~', '#':
-		return false
-	}
-	return true
 }
 
 // hasAllTags reports whether every entry in required appears in noteTags,

--- a/note/tags_test.go
+++ b/note/tags_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractHashtagsBasic(t *testing.T) {
@@ -88,4 +89,132 @@ func TestExtractHashtagsBareHash(t *testing.T) {
 		got := ExtractHashtags([]byte(in))
 		assert.Empty(t, got)
 	}
+}
+
+func TestIsTagRune(t *testing.T) {
+	yes := []rune{'a', 'Z', '0', '9', '_', '-', 'é', 'ü', 'я', '中', '工', '٢'}
+	for _, r := range yes {
+		assert.True(t, IsTagRune(r), "expected %q to be a tag rune", r)
+	}
+	no := []rune{' ', '.', '/', '#', '\t', '\n', '!', ',', '(', ')'}
+	for _, r := range no {
+		assert.False(t, IsTagRune(r), "expected %q not to be a tag rune", r)
+	}
+}
+
+func TestValidateTag(t *testing.T) {
+	valid := []string{"a", "Work", "work-stuff", "snake_case", "1tag", "café", "工作", "mixed_тест-1", "ü"}
+	for _, s := range valid {
+		assert.NoError(t, ValidateTag(s), "expected %q to be valid", s)
+	}
+	invalid := []string{"", "has space", "tag.", "/foo", "#tag", "a/b", "a b c", "tag!"}
+	for _, s := range invalid {
+		assert.Error(t, ValidateTag(s), "expected %q to be invalid", s)
+	}
+}
+
+func TestExtractHashtagsUnicode(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"latin extended", "#café", []string{"café"}},
+		{"cjk", "#工作", []string{"工作"}},
+		{"mixed script", "#mixed_тест-1", []string{"mixed_тест-1"}},
+		{"adjacent prose latin", "café#bar", nil},
+		{"adjacent prose cyrillic", "работа#tag", nil},
+		{"period terminates", "#tag.", []string{"tag"}},
+		{"chained still rejected", "#tag#other", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ExtractHashtags([]byte(c.in))
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+func TestReplaceBodyHashtagsBasic(t *testing.T) {
+	replace := func(_ []byte) []byte { return []byte("#personal") }
+	out, n := ReplaceBodyHashtags([]byte("here is #work, ok"), "work", replace)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "here is #personal, ok", string(out))
+}
+
+func TestReplaceBodyHashtagsCaseInsensitive(t *testing.T) {
+	replace := func(_ []byte) []byte { return []byte("#personal") }
+	in := "a #Work b #WORK c #work d"
+	out, n := ReplaceBodyHashtags([]byte(in), "work", replace)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, "a #personal b #personal c #personal d", string(out))
+}
+
+func TestReplaceBodyHashtagsCallbackReceivesOriginal(t *testing.T) {
+	var seen []string
+	replace := func(token []byte) []byte {
+		seen = append(seen, string(token))
+		return token // strip '#' (callback shape future tags rm needs)
+	}
+	in := "x #Work y #work z"
+	out, n := ReplaceBodyHashtags([]byte(in), "work", replace)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, []string{"Work", "work"}, seen)
+	assert.Equal(t, "x Work y work z", string(out))
+}
+
+func TestReplaceBodyHashtagsSkipsCodeFences(t *testing.T) {
+	replace := func(_ []byte) []byte { return []byte("#personal") }
+	in := "before #work\n```\n#work hidden\n```\nafter #work\n"
+	out, n := ReplaceBodyHashtags([]byte(in), "work", replace)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, "before #personal\n```\n#work hidden\n```\nafter #personal\n", string(out))
+}
+
+func TestReplaceBodyHashtagsSkipsInlineBackticks(t *testing.T) {
+	replace := func(_ []byte) []byte { return []byte("#personal") }
+	in := "real #work and `inline #work` and trailing #work"
+	out, n := ReplaceBodyHashtags([]byte(in), "work", replace)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, "real #personal and `inline #work` and trailing #personal", string(out))
+}
+
+func TestReplaceBodyHashtagsSkipsHeading(t *testing.T) {
+	replace := func(_ []byte) []byte { return []byte("#personal") }
+	in := "# work\nbody #work here\n## work\n"
+	out, n := ReplaceBodyHashtags([]byte(in), "work", replace)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "# work\nbody #personal here\n## work\n", string(out))
+}
+
+func TestReplaceBodyHashtagsSkipsURLAnchor(t *testing.T) {
+	replace := func(_ []byte) []byte { return []byte("#personal") }
+	in := "see example.com/#work and https://x/y#work but #work here"
+	out, n := ReplaceBodyHashtags([]byte(in), "work", replace)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "see example.com/#work and https://x/y#work but #personal here", string(out))
+}
+
+func TestReplaceBodyHashtagsUnicode(t *testing.T) {
+	replace := func(_ []byte) []byte { return []byte("#latte") }
+	in := "drink #café please"
+	out, n := ReplaceBodyHashtags([]byte(in), "café", replace)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, "drink #latte please", string(out))
+}
+
+func TestReplaceBodyHashtagsNoMatch(t *testing.T) {
+	replace := func(_ []byte) []byte { return []byte("#personal") }
+	in := "no tag here, just #other"
+	out, n := ReplaceBodyHashtags([]byte(in), "work", replace)
+	assert.Equal(t, 0, n)
+	require.Equal(t, "no tag here, just #other", string(out))
+}
+
+func TestReplaceBodyHashtagsMultiplePerLine(t *testing.T) {
+	replace := func(_ []byte) []byte { return []byte("#personal") }
+	in := "#work and #work on same line\nand #work next\n"
+	out, n := ReplaceBodyHashtags([]byte(in), "work", replace)
+	assert.Equal(t, 3, n)
+	assert.Equal(t, "#personal and #personal on same line\nand #personal next\n", string(out))
 }


### PR DESCRIPTION
## Summary

Adds a new `notes tags rename <old> <new>` command to rename tags across the entire store, rewriting both frontmatter `tags:` lists and body `#hashtag` tokens. Also extends hashtag parsing to support unicode letters and digits, not just ASCII.

### Key Changes

**New Features:**
- `notes tags rename <old> <new>` command that:
  - Matches tags case-insensitively across frontmatter and body
  - Writes the new tag name literally (preserving user-specified casing)
  - Supports `--dry-run` flag to preview changes without writing
  - Returns partial results if a write fails mid-operation
  - Locks the store root during execution to prevent concurrent modifications

- `notes tags list` as an explicit alias for `notes tags`

**Unicode Support:**
- Hashtag tokens now accept any unicode letter or digit (e.g., `#café`, `#工作`, `#тест`), not just ASCII `[A-Za-z0-9_-]`
- Added `IsTagRune()` and `ValidateTag()` functions for tag validation
- Updated hashtag detection to use unicode-aware rune operations instead of byte-level checks
- Prevents false matches adjacent to non-ASCII prose (e.g., `café#bar` no longer matches)

**Implementation Details:**
- New `ReplaceBodyHashtags()` function to rewrite hashtags in note bodies while respecting code fences, inline backticks, URLs, and markdown headings
- Refactored `ExtractHashtags()` to use shared `scanBodyAbs()` helper for consistent hashtag detection
- `RenameTag()` function orchestrates the rename operation across all matching notes
- `rewriteMetaTags()` deduplicates case variants and ensures the new tag form wins

## References

- Closes #273