### PR TITLE
Add `notes tags rm` command to delete tags across the store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `notes tags rename <old> <new>` renames a tag across the store, rewriting frontmatter `tags:` lists and body `#hashtag` tokens. Matches case-insensitively; writes the new name literally. Supports `--dry-run`.
+- `notes tags rm <name>` deletes a tag across the store. Drops the tag from frontmatter `tags:` lists and strips the leading `#` from inline `#name` tokens in note bodies, leaving the bare word as prose. Matches case-insensitively. Supports `--dry-run`.
 - `notes tags list` (explicit alias for `notes tags`).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ notes tags list                     # explicit alias
 notes tags rename work personal
 notes tags rename --dry-run work personal
 
+# Delete a tag across the whole store (frontmatter dropped, body '#name' becomes 'name')
+notes tags rm work
+notes tags rm --dry-run work
+
 # Print the effective runtime configuration (resolved store path, defaults, env vars)
 notes config
 ```

--- a/internal/cli/tags.go
+++ b/internal/cli/tags.go
@@ -75,6 +75,48 @@ var tagsRenameCmd = &cobra.Command{
 	},
 }
 
+var tagsRmCmd = &cobra.Command{
+	Use:   "rm <name>",
+	Short: "Delete a tag across the store (drops frontmatter entries, strips '#' from body tokens)",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+
+		if name == "" {
+			return fmt.Errorf("tag is empty")
+		}
+
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		store, err := notesStore()
+		if err != nil {
+			return err
+		}
+
+		res, rmErr := note.RemoveTag(store, name, note.RemoveOpts{DryRun: dryRun})
+
+		out := cmd.OutOrStdout()
+		errOut := cmd.ErrOrStderr()
+		for _, p := range res.ModifiedPaths {
+			fmt.Fprintln(out, p)
+		}
+
+		n := len(res.ModifiedPaths)
+		switch {
+		case rmErr != nil:
+			fmt.Fprintf(errOut, "partial: removed in %s before error\n", pluralNotes(n))
+			return rmErr
+		case n == 0:
+			fmt.Fprintf(errOut, "no notes contained tag %q\n", name)
+		case dryRun:
+			fmt.Fprintf(errOut, "would remove tag %q from %s\n", name, pluralNotes(n))
+		default:
+			fmt.Fprintf(errOut, "removed tag %q from %s\n", name, pluralNotes(n))
+		}
+		return nil
+	},
+}
+
 func pluralNotes(n int) string {
 	if n == 1 {
 		return "1 note"
@@ -111,7 +153,9 @@ func runTagsList(cmd *cobra.Command) error {
 
 func init() {
 	tagsRenameCmd.Flags().Bool("dry-run", false, "print modifications without writing")
+	tagsRmCmd.Flags().Bool("dry-run", false, "print modifications without writing")
 	tagsCmd.AddCommand(tagsListCmd)
 	tagsCmd.AddCommand(tagsRenameCmd)
+	tagsCmd.AddCommand(tagsRmCmd)
 	rootCmd.AddCommand(tagsCmd)
 }

--- a/internal/cli/tags_test.go
+++ b/internal/cli/tags_test.go
@@ -16,6 +16,7 @@ import (
 // (e.g. --dry-run) into each other.
 func resetTagsFlags() {
 	_ = tagsRenameCmd.Flags().Set("dry-run", "false")
+	_ = tagsRmCmd.Flags().Set("dry-run", "false")
 }
 
 func runTags(t *testing.T, root string, args ...string) (string, error) {
@@ -207,6 +208,75 @@ func TestTagsRenameUnicode(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(got), "tags:\n    - latte")
 	assert.Contains(t, string(got), "drink #latte please")
+}
+
+func TestTagsRmHappyPath(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	path := filepath.Join(root, "2026", "01", "20260101_1.md")
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [work]\n---\n\nbody #work here\n")
+
+	stdout, stderr, err := runTagsSplit(t, root, "rm", "work")
+	require.NoError(t, err)
+	assert.Equal(t, path+"\n", stdout)
+	assert.Equal(t, "removed tag \"work\" from 1 note\n", stderr)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.NotContains(t, string(got), "- work")
+	assert.Contains(t, string(got), "body work here")
+	assert.NotContains(t, string(got), "#work")
+}
+
+func TestTagsRmDryRun(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	path := filepath.Join(root, "2026", "01", "20260101_1.md")
+	content := "---\ntags: [work]\n---\n\nbody #work here\n"
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md", content)
+
+	stdout, stderr, err := runTagsSplit(t, root, "rm", "--dry-run", "work")
+	require.NoError(t, err)
+	assert.Equal(t, path+"\n", stdout)
+	assert.Equal(t, "would remove tag \"work\" from 1 note\n", stderr)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got), "file should be untouched in dry-run")
+}
+
+func TestTagsRmEmptyArgFails(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+
+	_, _, err := runTagsSplit(t, root, "rm", "")
+	require.Error(t, err)
+}
+
+func TestTagsRmNoMatches(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [other]\n---\n\nbody\n")
+
+	stdout, stderr, err := runTagsSplit(t, root, "rm", "nope")
+	require.NoError(t, err)
+	assert.Empty(t, strings.TrimSpace(stdout))
+	assert.Equal(t, "no notes contained tag \"nope\"\n", stderr)
+}
+
+func TestTagsRmHappyPathPlural(t *testing.T) {
+	root := t.TempDir()
+	writeIDJSON(t, root)
+	writeTagsTestNote(t, root, "2026/01/20260101_1.md",
+		"---\ntags: [work]\n---\n\na\n")
+	writeTagsTestNote(t, root, "2026/01/20260102_2.md",
+		"---\ntags: [work]\n---\n\nb\n")
+
+	_, stderr, err := runTagsSplit(t, root, "rm", "work")
+	require.NoError(t, err)
+	assert.Equal(t, "removed tag \"work\" from 2 notes\n", stderr)
 }
 
 func TestTagsRenameCaseOnly(t *testing.T) {

--- a/note/rename.go
+++ b/note/rename.go
@@ -67,6 +67,87 @@ func RenameTag(store *OSStore, oldTag, newTag string, opts RenameOpts) (RenameRe
 	return result, nil
 }
 
+// RemoveOpts configures RemoveTag.
+type RemoveOpts struct {
+	// DryRun reports the modified paths without writing.
+	DryRun bool
+}
+
+// RemoveResult is the outcome of a RemoveTag call.
+type RemoveResult struct {
+	// ModifiedPaths lists the absolute path of every note that was (or
+	// would be, in dry-run mode) modified, in newest-first order.
+	ModifiedPaths []string
+}
+
+// RemoveTag deletes the tag (matched case-insensitively) across the store.
+// Frontmatter entries equal to name (case-insensitively) are dropped. Inline
+// body "#name" tokens have their leading '#' stripped, leaving the bare word
+// as prose. The store root is locked for the duration — including dry-run, so
+// the previewed path list reflects a consistent snapshot. On mid-run failure,
+// RemoveTag returns the error together with the partial path list of notes
+// already written.
+func RemoveTag(store *OSStore, name string, opts RemoveOpts) (RemoveResult, error) {
+	unlock, err := lockStoreRoot(store.Root())
+	if err != nil {
+		return RemoveResult{}, err
+	}
+	defer unlock()
+
+	lowerName := strings.ToLower(name)
+
+	entries, err := store.All(WithTag(name))
+	if err != nil {
+		return RemoveResult{}, err
+	}
+
+	stripFn := func(token []byte) []byte { return token }
+
+	var result RemoveResult
+	for _, entry := range entries {
+		newTags, tagsChanged := dropMetaTag(entry.Meta.Tags, lowerName)
+		newBody, bodyN := ReplaceBodyHashtags([]byte(entry.Body), lowerName, stripFn)
+
+		if !tagsChanged && bodyN == 0 {
+			continue
+		}
+
+		entry.Meta.Tags = newTags
+		entry.Body = string(newBody)
+
+		if opts.DryRun {
+			result.ModifiedPaths = append(result.ModifiedPaths, store.AbsPath(entry))
+			continue
+		}
+
+		saved, err := store.Put(entry)
+		if err != nil {
+			return result, err
+		}
+		result.ModifiedPaths = append(result.ModifiedPaths, store.AbsPath(saved))
+	}
+
+	return result, nil
+}
+
+// dropMetaTag returns the tag list with every case-variant of lowerName
+// removed, and whether any change occurred.
+func dropMetaTag(tags []string, lowerName string) ([]string, bool) {
+	matched := false
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if strings.ToLower(t) == lowerName {
+			matched = true
+			continue
+		}
+		out = append(out, t)
+	}
+	if !matched {
+		return tags, false
+	}
+	return out, true
+}
+
 // rewriteMetaTags returns the rewritten tag list and whether any change
 // occurred. Every case-variant of lowerOld is dropped; if at least one was
 // present, newTag is appended and any pre-existing case variant of newTag

--- a/note/rm_test.go
+++ b/note/rm_test.go
@@ -1,0 +1,212 @@
+package note
+
+import (
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveTag_FrontmatterOnly(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"work", "personal"}, "no body tag\n")
+
+	res, err := RemoveTag(s, "work", RemoveOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	tags := readTags(t, res.ModifiedPaths[0])
+	assert.Equal(t, []string{"personal"}, tags)
+	body := readBody(t, res.ModifiedPaths[0])
+	assert.Equal(t, "no body tag\n", body)
+}
+
+func TestRemoveTag_BodyOnly(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	// Body has the removed tag plus an unrelated hashtag. The unrelated
+	// hashtag is promoted to frontmatter on write (documented behavior).
+	putForRename(t, s, day, nil, "text #work more and #other\n")
+
+	res, err := RemoveTag(s, "work", RemoveOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	body := readBody(t, res.ModifiedPaths[0])
+	assert.Equal(t, "text work more and #other\n", body)
+	tags := readTags(t, res.ModifiedPaths[0])
+	assert.Equal(t, []string{"other"}, tags)
+}
+
+func TestRemoveTag_FrontmatterAndBody(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"work"}, "ref #work here\n")
+
+	res, err := RemoveTag(s, "work", RemoveOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	body := readBody(t, res.ModifiedPaths[0])
+	assert.Equal(t, "ref work here\n", body)
+	tags := readTags(t, res.ModifiedPaths[0])
+	assert.Empty(t, tags)
+}
+
+func TestRemoveTag_MixedCaseAcrossNotes(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, nil, "see #Work here\n")
+	putForRename(t, s, day, nil, "see #WORK here\n")
+	putForRename(t, s, day, nil, "see #work here\n")
+
+	res, err := RemoveTag(s, "work", RemoveOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 3)
+
+	bodies := make([]string, 0, 3)
+	for _, p := range res.ModifiedPaths {
+		bodies = append(bodies, readBody(t, p))
+		assert.Empty(t, readTags(t, p))
+	}
+	assert.ElementsMatch(t, []string{
+		"see Work here\n",
+		"see WORK here\n",
+		"see work here\n",
+	}, bodies)
+}
+
+func TestRemoveTag_ZeroMatches(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"other"}, "no tag here\n")
+
+	res, err := RemoveTag(s, "work", RemoveOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, res.ModifiedPaths)
+}
+
+func TestRemoveTag_DryRun(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	e := putForRename(t, s, day, []string{"work"}, "ref #work\n")
+	originalInfo, err := os.Stat(s.AbsPath(e))
+	require.NoError(t, err)
+	originalMtime := originalInfo.ModTime()
+
+	time.Sleep(10 * time.Millisecond)
+
+	res, err := RemoveTag(s, "work", RemoveOpts{DryRun: true})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	info, err := os.Stat(s.AbsPath(e))
+	require.NoError(t, err)
+	assert.True(t, info.ModTime().Equal(originalMtime), "file mtime should be unchanged in dry-run")
+
+	tags := readTags(t, s.AbsPath(e))
+	assert.Equal(t, []string{"work"}, tags)
+	body := readBody(t, s.AbsPath(e))
+	assert.Equal(t, "ref #work\n", body)
+}
+
+func TestRemoveTag_PartialFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("filesystem-based failure injection is Unix-only")
+	}
+	s := newOSTestStore(t)
+	d1 := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	d2 := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+
+	e1 := putForRename(t, s, d1, []string{"work"}, "a\n")
+	e2 := putForRename(t, s, d2, []string{"work"}, "b\n")
+
+	first := s.AbsPath(e2)
+	second := s.AbsPath(e1)
+	require.NotEqual(t, first, second)
+
+	blocker := second + ".tmp"
+	require.NoError(t, os.MkdirAll(blocker, 0o755))
+	defer os.RemoveAll(blocker)
+
+	res, err := RemoveTag(s, "work", RemoveOpts{})
+	require.Error(t, err)
+
+	require.NoError(t, os.RemoveAll(blocker))
+	assert.Empty(t, readTags(t, first))
+	assert.Equal(t, []string{"work"}, readTags(t, second))
+
+	assert.Equal(t, []string{first}, res.ModifiedPaths)
+}
+
+func TestRemoveTag_BodyTagInsideCodeFenceIsNoop(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	body := "before\n```\n#work hidden\n```\nafter\n"
+	e := putForRename(t, s, day, nil, body)
+
+	res, err := RemoveTag(s, "work", RemoveOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, res.ModifiedPaths)
+
+	got := readBody(t, s.AbsPath(e))
+	assert.Equal(t, body, got)
+}
+
+func TestRemoveTag_URLAndHeadingGuards(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	body := "See [docs](https://example.com/#work) and #work and\n# work\nend\n"
+	putForRename(t, s, day, nil, body)
+
+	res, err := RemoveTag(s, "work", RemoveOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	got := readBody(t, res.ModifiedPaths[0])
+	want := "See [docs](https://example.com/#work) and work and\n# work\nend\n"
+	assert.Equal(t, want, got)
+}
+
+func TestRemoveTag_InlineCodeIsNoop(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	body := "prose `#work` continues\n"
+	e := putForRename(t, s, day, nil, body)
+
+	res, err := RemoveTag(s, "work", RemoveOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, res.ModifiedPaths)
+
+	got := readBody(t, s.AbsPath(e))
+	assert.Equal(t, body, got)
+}
+
+func TestRemoveTag_UnicodeCasePreserved(t *testing.T) {
+	s := newOSTestStore(t)
+	day := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	putForRename(t, s, day, []string{"café"}, "drink #Café please\n")
+
+	res, err := RemoveTag(s, "café", RemoveOpts{})
+	require.NoError(t, err)
+	require.Len(t, res.ModifiedPaths, 1)
+
+	body := readBody(t, res.ModifiedPaths[0])
+	assert.Equal(t, "drink Café please\n", body)
+	tags := readTags(t, res.ModifiedPaths[0])
+	assert.Empty(t, tags)
+}

--- a/note/tags_test.go
+++ b/note/tags_test.go
@@ -211,6 +211,29 @@ func TestReplaceBodyHashtagsNoMatch(t *testing.T) {
 	require.Equal(t, "no tag here, just #other", string(out))
 }
 
+func TestReplaceBodyHashtagsStripModePreservesCase(t *testing.T) {
+	strip := func(token []byte) []byte { return token }
+	cases := []struct {
+		name  string
+		in    string
+		match string
+		want  string
+		n     int
+	}{
+		{"lower", "see #work here", "work", "see work here", 1},
+		{"upper", "see #WORK here", "work", "see WORK here", 1},
+		{"unicode", "drink #Café please", "café", "drink Café please", 1},
+		{"mixed body", "tag #work and #other", "work", "tag work and #other", 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, n := ReplaceBodyHashtags([]byte(c.in), c.match, strip)
+			assert.Equal(t, c.n, n)
+			assert.Equal(t, c.want, string(out))
+		})
+	}
+}
+
 func TestReplaceBodyHashtagsMultiplePerLine(t *testing.T) {
 	replace := func(_ []byte) []byte { return []byte("#personal") }
 	in := "#work and #work on same line\nand #work next\n"


### PR DESCRIPTION
## Summary

Adds a new `notes tags rm <name>` command that deletes a tag across the entire store. The command:
- Removes the tag from frontmatter `tags:` lists (case-insensitive matching)
- Strips the `#` prefix from matching body hashtags, leaving the bare word as prose
- Supports `--dry-run` to preview changes without writing
- Handles partial failures gracefully, returning modified paths alongside errors
- Preserves case in body text when stripping hashtags

Implements the core `RemoveTag()` function in `note/rename.go` with comprehensive test coverage in `note/rm_test.go`, and wires it into the CLI via `internal/cli/tags.go`.

## References

- Closes #274
