### PR TITLE
Release version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-11
+
 ### Added
 
 - `notes tags rename <old> <new>` renames a tag across the store, rewriting frontmatter `tags:` lists and body `#hashtag` tokens. Matches case-insensitively; writes the new name literally. Supports `--dry-run`.


### PR DESCRIPTION
## Summary

- Release version 0.4.0 with tag rename feature

## Notes

This release includes the new `notes tags rename` command that allows renaming tags across the entire store, updating both frontmatter `tags:` lists and body `#hashtag` tokens with `--dry-run` support.
