### PR TITLE
Add `notes skill` command for AI agent integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-14
+
+### Added
+
+- `notes skill` prints an AI-assistant skill document describing how to drive the CLI. The skill is authored as a markdown file in the repository and embedded into the binary at build time, so the same bytes ship with every copy of a given build. Pass `--install` to write the skill into a known agent location (currently `~/.claude/skills/notes/SKILL.md`), with `--agent`, `--force`, and `--dry-run` for the usual safety controls; without `--agent` the command auto-detects installed agents.
+
 ## [0.4.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ notes tags rm --dry-run work
 
 # Print the effective runtime configuration (resolved store path, defaults, env vars)
 notes config
+
+# Print an AI-assistant skill describing how to drive notes
+notes skill
+notes skill --install                # auto-detect agents, install into each
+notes skill --install --agent=claude # install into a specific agent
+notes skill --install --dry-run      # show planned actions, write nothing
+notes skill --install --force        # overwrite a diverging existing skill
 ```
 
 Composing with the shell — since most commands take an ID, use `ls` or

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -1,0 +1,306 @@
+package cli
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed skill.md
+var skillContent string
+
+// homeDir is overridable in tests so install-mode paths under "~" can be
+// redirected to a temporary directory.
+var homeDir = os.UserHomeDir
+
+// agentTarget is a supported AI assistant. The registry is the package
+// variable agents below; new entries are added by appending.
+type agentTarget struct {
+	Name    string
+	PathFor func() (string, error)
+	Detect  func() (bool, error)
+}
+
+var agents = []agentTarget{
+	{
+		Name: "claude",
+		PathFor: func() (string, error) {
+			home, err := homeDir()
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(home, ".claude", "skills", "notes", "SKILL.md"), nil
+		},
+		Detect: func() (bool, error) {
+			home, err := homeDir()
+			if err != nil {
+				return false, err
+			}
+			_, err = os.Stat(filepath.Join(home, ".claude", "skills"))
+			if err == nil {
+				return true, nil
+			}
+			if errors.Is(err, os.ErrNotExist) {
+				return false, nil
+			}
+			return false, err
+		},
+	},
+}
+
+// installAction is a single planned filesystem operation against one
+// agent target. See specs/001-generate-skill/data-model.md.
+type installAction struct {
+	Agent  string
+	Path   string
+	Action string
+	Error  error
+}
+
+const (
+	actionCreate    = "create"
+	actionSkip      = "skip"
+	actionConflict  = "conflict"
+	actionOverwrite = "overwrite"
+)
+
+var (
+	skillInstall bool
+	skillAgent   string
+	skillForce   bool
+	skillDryRun  bool
+)
+
+var skillCmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Print or install the notes agent skill",
+	Long: `Print a self-contained markdown document describing how an AI
+agent should drive the notes CLI. The skill is authored as a markdown
+file in the repository and embedded into the binary at build time, so
+the same bytes are emitted across machines.
+
+With --install, the skill is written to a known per-agent location
+instead of stdout. Supported agents are listed below.
+
+Supported --agent values:
+  claude    ~/.claude/skills/notes/SKILL.md
+
+Actions (install mode):
+  create     destination did not exist; written
+  skip       destination existed with identical content; not written
+  conflict   destination existed with different content; not written, exit non-zero
+  overwrite  destination existed with different content and --force was set; written`,
+	Args: cobra.NoArgs,
+	RunE: skillRunE,
+}
+
+func skillRunE(cmd *cobra.Command, _ []string) error {
+	if err := validateSkillFlags(); err != nil {
+		return err
+	}
+
+	if !skillInstall {
+		_, err := io.WriteString(cmd.OutOrStdout(), skillContent)
+		return err
+	}
+
+	targets, err := resolveTargets()
+	if err != nil {
+		return err
+	}
+
+	actions := planInstall(skillContent, targets)
+	if err := applyInstall(actions, skillDryRun); err != nil {
+		return err
+	}
+	printActions(cmd.OutOrStdout(), actions, skillDryRun)
+	return exitErrorFor(actions)
+}
+
+func validateSkillFlags() error {
+	if !skillInstall {
+		switch {
+		case skillAgent != "":
+			return errors.New("--agent requires --install")
+		case skillForce:
+			return errors.New("--force requires --install")
+		case skillDryRun:
+			return errors.New("--dry-run requires --install")
+		}
+	}
+	if skillAgent != "" && findAgent(skillAgent) == nil {
+		return fmt.Errorf("unknown agent %q (supported: %s)", skillAgent, agentNamesList())
+	}
+	return nil
+}
+
+func findAgent(name string) *agentTarget {
+	for i := range agents {
+		if agents[i].Name == name {
+			return &agents[i]
+		}
+	}
+	return nil
+}
+
+func agentNamesList() string {
+	names := make([]string, len(agents))
+	for i, a := range agents {
+		names[i] = a.Name
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// resolveTargets returns the agent targets to act on for the current
+// invocation: either the single agent named by --agent, or every detected
+// agent when --agent is empty.
+func resolveTargets() ([]agentTarget, error) {
+	if skillAgent != "" {
+		return []agentTarget{*findAgent(skillAgent)}, nil
+	}
+	var detected []agentTarget
+	for _, a := range agents {
+		ok, err := a.Detect()
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			detected = append(detected, a)
+		}
+	}
+	if len(detected) == 0 {
+		return nil, fmt.Errorf("no supported agent detected; pass --agent explicitly (supported: %s)", agentNamesList())
+	}
+	return detected, nil
+}
+
+// planInstall computes the action for each target without writing
+// anything. An OS error while reading an existing destination is
+// captured in the action's Error field rather than aborting the whole
+// plan.
+func planInstall(content string, targets []agentTarget) []installAction {
+	bytesContent := []byte(content)
+	actions := make([]installAction, len(targets))
+	for i, t := range targets {
+		actions[i] = planOne(t, bytesContent)
+	}
+	return actions
+}
+
+func planOne(t agentTarget, content []byte) installAction {
+	path, err := t.PathFor()
+	if err != nil {
+		return installAction{Agent: t.Name, Error: err}
+	}
+	existing, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return installAction{Agent: t.Name, Path: path, Action: actionCreate}
+	case err != nil:
+		return installAction{Agent: t.Name, Path: path, Error: err}
+	}
+	if string(existing) == string(content) {
+		return installAction{Agent: t.Name, Path: path, Action: actionSkip}
+	}
+	if skillForce {
+		return installAction{Agent: t.Name, Path: path, Action: actionOverwrite}
+	}
+	return installAction{Agent: t.Name, Path: path, Action: actionConflict}
+}
+
+// applyInstall performs the writes implied by the action plan. In
+// dryRun mode, it does nothing and returns nil.
+func applyInstall(actions []installAction, dryRun bool) error {
+	if dryRun {
+		return nil
+	}
+	content := []byte(skillContent)
+	for i := range actions {
+		a := &actions[i]
+		if a.Error != nil {
+			continue
+		}
+		if a.Action != actionCreate && a.Action != actionOverwrite {
+			continue
+		}
+		if err := writeSkillFile(a.Path, content); err != nil {
+			a.Error = err
+		}
+	}
+	return nil
+}
+
+// writeSkillFile creates the parent directory if its parent already
+// exists (e.g. creates ~/.claude/skills/notes/ when ~/.claude/skills/
+// exists), but refuses to materialise an absent agent skills directory.
+// That absence is the detection signal that the user does not run this
+// agent.
+func writeSkillFile(path string, content []byte) error {
+	parent := filepath.Dir(path)
+	if _, err := os.Stat(parent); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		grandparent := filepath.Dir(parent)
+		if _, gerr := os.Stat(grandparent); gerr != nil {
+			return fmt.Errorf("agent skills directory not found: %s", grandparent)
+		}
+		if err := os.MkdirAll(parent, 0o755); err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(path, content, 0o644)
+}
+
+func printActions(out io.Writer, actions []installAction, dryRun bool) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	for _, a := range actions {
+		if a.Error != nil {
+			fmt.Fprintf(w, "error\t%s\t%s\n", a.Agent, a.Error)
+			continue
+		}
+		verb := a.Action
+		if dryRun {
+			verb = "would " + verb
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\n", verb, a.Agent, a.Path)
+	}
+	_ = w.Flush()
+}
+
+func exitErrorFor(actions []installAction) error {
+	var problems []string
+	for _, a := range actions {
+		switch {
+		case a.Error != nil:
+			problems = append(problems, fmt.Sprintf("%s: %s", a.Agent, a.Error))
+		case a.Action == actionConflict:
+			problems = append(problems, fmt.Sprintf("%s: destination exists with different content; pass --force to overwrite", a.Agent))
+		}
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(problems, "; "))
+}
+
+func registerSkillFlags() {
+	skillCmd.Flags().BoolVar(&skillInstall, "install", false, "install the skill into one or more agent locations")
+	skillCmd.Flags().StringVar(&skillAgent, "agent", "", "install only into the named agent (default: auto-detect)")
+	skillCmd.Flags().BoolVar(&skillForce, "force", false, "overwrite an existing destination with diverging content")
+	skillCmd.Flags().BoolVarP(&skillDryRun, "dry-run", "n", false, "print planned actions but do not write any files")
+}
+
+func init() {
+	registerSkillFlags()
+	rootCmd.AddCommand(skillCmd)
+}

--- a/internal/cli/skill.md
+++ b/internal/cli/skill.md
@@ -1,52 +1,193 @@
 ---
 name: notes
-description: Use when interacting with a notes store via the notes CLI — creating, reading, listing, updating, annotating, or deleting notes managed under a date-stamped markdown archive.
+description: Use the notes CLI to create, list, read, append to, update, annotate, and delete notes in a date-based markdown archive — including daily todos with task rollover and tag operations across the store.
 ---
 
-# notes
+# Notes Skill
 
-## Overview
+Use the `notes` CLI for all note operations. All commands respect `$NOTES_PATH` or `--path` (one MUST be set; there is no implicit default).
 
-`notes` is a command-line interface for a plain-text note archive. Each note is a markdown file with a YAML frontmatter block, stored under a date-stamped directory tree (`YYYY/YYYYMMDD_NNNN.md`). There is no database, no proprietary format, and no sync service — the files are owned by the user. The CLI provides scriptable access to create, read, list, update, annotate, and delete notes.
+## Basics
 
-## Global flags
+- **Location**: `$NOTES_PATH` (or `--path`); no default — the CLI exits with an error if neither is set.
+- **Directory pattern**: `YYYY/MM/YYYYMMDD_ID[_slug][.type].md`
+- **UID**: `YYYYMMDD_ID` uniquely identifies each note. `ID` is a small integer that is unique within a day.
+- **Type-bearing notes** (`todo`, `backlog`, `weekly`) embed the type as a dot-suffix in the filename, e.g. `20260102_8814.todo.md`. Other types live in the frontmatter only.
 
-- `--path` — path to notes store (default: $NOTES_PATH)
+The authoritative frontmatter schema is `SCHEMA.md` in the repository. Reserved keys: `title`, `slug`, `type`, `date`, `tags`, `aliases`, `description`, `public`. Unknown keys are preserved verbatim.
 
-## Commands
+## Frontmatter Guidelines
 
-- `notes annotate` — Fill empty frontmatter (title, description, tags) using Claude Code
-- `notes append` — Append text from stdin to a note
-- `notes config` — Print the effective runtime configuration
-- `notes ls` — List note IDs, newest first
-- `notes new` — Create a new note
-- `notes new-todo` — Create today's todo, carrying over incomplete tasks from the previous todo
-- `notes read` — Read a note
-- `notes resolve` — Print the absolute path of a note
-- `notes rm` — Delete a note
-- `notes skill` — Print or install the notes agent skill
-- `notes tags` — List all tags from frontmatter and body hashtags
-- `notes update` — Update note frontmatter (file is renamed automatically when slug, type, or date changes)
+- Include only the fields that are explicitly requested or clearly applicable; everything is optional.
+- Do NOT add a `date` field unless the authored date differs from the UID date — the UID-derived date in the filename is the canonical source.
+- Add `description` when there is clear context behind the note (e.g. responding to a message, capturing a decision). Use it to record the context/intention, not a summary of the body.
+- Inline `#hashtag` tokens in the body are indexed by `notes tags`; they are a separate feature from the `tags` frontmatter list.
+- The `slug` in frontmatter is canonical. The filename caches it; on mismatch, frontmatter wins.
 
-Run `notes <command> --help` for the full flag list and behaviour of each command.
+## CLI Reference
 
-## Store layout
+Most commands that act on a specific note take a numeric ID. To act on "the most recent note of type X" or "the most recent note with slug Y", use `notes ls --limit 1` or `notes resolve` to turn a filter into an ID and shell-substitute.
 
-The notes store path is resolved in this order: `--path` flag, then `NOTES_PATH` environment variable. If neither is set, the CLI exits with an error. There is no implicit default.
+### Create
 
-Each note lives at `<store>/<YYYY>/<YYYYMMDD>_<NNNN>.md`, where `NNNN` is a per-day numeric ID. Note IDs are unique within a day; CLI commands that take an ID accept the numeric portion (e.g. `notes read 8823`). Frontmatter is YAML with optional `title`, `slug`, `type`, `tags`, `description`, and `public` fields. Inline `#hashtag` tokens in the body are also indexed.
+```sh
+# Empty note
+notes new
+
+# Note from stdin with frontmatter
+echo "# Content" | notes new --title "Title" --tag journal --tag idea --description "Context"
+
+# Note with a slug
+echo "# Content" | notes new --slug my-slug
+
+# Typed note (todo / backlog / weekly trigger special handling; any other type is fine too)
+echo "# Content" | notes new --type todo
+
+# Upsert: reuse today's note if one already matches --type/--slug
+echo "# Content" | notes new --type todo --upsert
+
+# Today's todo (carries over incomplete tasks from the previous todo)
+notes new-todo
+```
+
+`notes new` and `notes new-todo` print the absolute path of the created (or reused) file to stdout.
+
+### List
+
+```sh
+# Most recent IDs, newest first
+notes ls --limit 10
+
+# Filter by type, slug, or tag (--tag is repeatable; tags AND together)
+notes ls --type todo --limit 1
+notes ls --slug report
+notes ls --tag journal --tag idea
+
+# Only today's notes
+notes ls --today
+```
+
+### Read
+
+```sh
+notes read 8823
+notes read 8823 --no-frontmatter
+```
+
+`notes read` requires a numeric ID. Compose with `ls` or `resolve` to read a filtered note:
+
+```sh
+# Read the most recent todo
+notes read "$(notes ls --type todo --limit 1)"
+```
+
+### Resolve (get path)
+
+```sh
+notes resolve                    # most recent note overall
+notes resolve --id 8823          # exact ID
+notes resolve --type todo        # most recent note of that type
+notes resolve --slug meeting     # most recent note with that slug
+notes resolve --tag work         # most recent note with that tag
+```
+
+At most one lookup flag may be provided.
+
+### Append
+
+```sh
+echo "more text" | notes append 8823
+
+# Append to the latest note matching a filter via shell substitution
+echo "more text" | notes append "$(notes ls --slug claude-sessions --limit 1)"
+```
+
+### Update
+
+```sh
+# Set fields
+notes update 8823 --title "New Title"
+notes update 8823 --description "One-line summary"
+notes update 8823 --tag work --tag planning   # replaces existing tags
+
+# Remove fields
+notes update 8823 --no-tags
+notes update 8823 --no-slug
+notes update 8823 --no-type
+
+# Rename / move (the file on disk is renamed automatically)
+notes update 8823 --slug meeting
+notes update 8823 --type todo
+notes update 8823 --date 20260420            # move to a different day
+
+# Visibility
+notes update 8823 --public
+notes update 8823 --private
+```
+
+### Delete
+
+```sh
+notes rm 8823
+```
+
+### Annotate (auto-fill frontmatter via Claude Code)
+
+```sh
+notes annotate 8823
+notes annotate 8823 --model claude-sonnet-4-6
+notes annotate 8823 --max-chars 4000   # truncate body before sending
+notes annotate 8823 --timeout 2m
+```
+
+`annotate` shells out to the `claude` CLI and requires `ANTHROPIC_API_KEY`.
+
+### Tags
+
+```sh
+# List all tags (frontmatter + body hashtags)
+notes tags
+notes tags list                  # explicit alias
+
+# Rename a tag across the whole store
+notes tags rename work personal
+notes tags rename --dry-run work personal
+
+# Delete a tag across the whole store (frontmatter dropped, body '#name' becomes 'name')
+notes tags rm work
+notes tags rm --dry-run work
+```
+
+### Config
+
+```sh
+notes config
+```
+
+Prints the resolved store path, default values for per-command flags, and the presence of required env vars (`NOTES_PATH`, `ANTHROPIC_API_KEY`). Never prints env values.
+
+### Skill (this document)
+
+```sh
+notes skill                              # print this skill to stdout
+notes skill --install                    # write into every detected agent's skills directory
+notes skill --install --agent=claude     # explicit single-agent install
+notes skill --install --force            # overwrite an existing diverging copy
+notes skill --install --dry-run          # print planned actions, write nothing
+```
+
+## Editing Notes
+
+Preserve YAML frontmatter structure when modifying notes. When cross-referencing other notes inside a note, prefer the UID (`YYYYMMDD_ID`) — it is stable across renames.
 
 ## Composing with the shell
 
-Most commands take a numeric note ID. To act on "the most recent note of type X" or "the most recent note with slug Y", use `notes ls` or `notes resolve` to turn a filter into an ID, then shell-substitute:
-
 ```sh
-# Append to the most recent note with a given slug
-echo "text" | notes append "$(notes ls --slug claude-sessions --limit 1)"
-
-# Read the most recent todo
-notes read "$(notes ls --type todo --limit 1)"
-
 # Open the most recent meeting note in $EDITOR
 $EDITOR "$(notes resolve --slug meeting)"
+
+# Append the current clipboard to today's todo
+pbpaste | notes append "$(notes ls --type todo --today --limit 1)"
 ```
+
+Run `notes <command> --help` for the full flag list of any command. Run `notes config` to inspect the effective runtime configuration.

--- a/internal/cli/skill.md
+++ b/internal/cli/skill.md
@@ -1,0 +1,52 @@
+---
+name: notes
+description: Use when interacting with a notes store via the notes CLI — creating, reading, listing, updating, annotating, or deleting notes managed under a date-stamped markdown archive.
+---
+
+# notes
+
+## Overview
+
+`notes` is a command-line interface for a plain-text note archive. Each note is a markdown file with a YAML frontmatter block, stored under a date-stamped directory tree (`YYYY/YYYYMMDD_NNNN.md`). There is no database, no proprietary format, and no sync service — the files are owned by the user. The CLI provides scriptable access to create, read, list, update, annotate, and delete notes.
+
+## Global flags
+
+- `--path` — path to notes store (default: $NOTES_PATH)
+
+## Commands
+
+- `notes annotate` — Fill empty frontmatter (title, description, tags) using Claude Code
+- `notes append` — Append text from stdin to a note
+- `notes config` — Print the effective runtime configuration
+- `notes ls` — List note IDs, newest first
+- `notes new` — Create a new note
+- `notes new-todo` — Create today's todo, carrying over incomplete tasks from the previous todo
+- `notes read` — Read a note
+- `notes resolve` — Print the absolute path of a note
+- `notes rm` — Delete a note
+- `notes skill` — Print or install the notes agent skill
+- `notes tags` — List all tags from frontmatter and body hashtags
+- `notes update` — Update note frontmatter (file is renamed automatically when slug, type, or date changes)
+
+Run `notes <command> --help` for the full flag list and behaviour of each command.
+
+## Store layout
+
+The notes store path is resolved in this order: `--path` flag, then `NOTES_PATH` environment variable. If neither is set, the CLI exits with an error. There is no implicit default.
+
+Each note lives at `<store>/<YYYY>/<YYYYMMDD>_<NNNN>.md`, where `NNNN` is a per-day numeric ID. Note IDs are unique within a day; CLI commands that take an ID accept the numeric portion (e.g. `notes read 8823`). Frontmatter is YAML with optional `title`, `slug`, `type`, `tags`, `description`, and `public` fields. Inline `#hashtag` tokens in the body are also indexed.
+
+## Composing with the shell
+
+Most commands take a numeric note ID. To act on "the most recent note of type X" or "the most recent note with slug Y", use `notes ls` or `notes resolve` to turn a filter into an ID, then shell-substitute:
+
+```sh
+# Append to the most recent note with a given slug
+echo "text" | notes append "$(notes ls --slug claude-sessions --limit 1)"
+
+# Read the most recent todo
+notes read "$(notes ls --type todo --limit 1)"
+
+# Open the most recent meeting note in $EDITOR
+$EDITOR "$(notes resolve --slug meeting)"
+```

--- a/internal/cli/skill_test.go
+++ b/internal/cli/skill_test.go
@@ -1,0 +1,270 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runSkill(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	skillCmd.ResetFlags()
+	registerSkillFlags()
+	skillInstall = false
+	skillAgent = ""
+	skillForce = false
+	skillDryRun = false
+
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs(append([]string{"skill"}, args...))
+
+	execErr := rootCmd.Execute()
+	return buf.String(), execErr
+}
+
+// sandboxHome redirects the package-level homeDir resolver to a fresh
+// tempdir for the lifetime of the test. Returns the sandbox path.
+func sandboxHome(t *testing.T, withClaudeSkills bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	if withClaudeSkills {
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".claude", "skills"), 0o755))
+	}
+	prev := homeDir
+	homeDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { homeDir = prev })
+	return dir
+}
+
+func TestSkillStdoutHasFrontmatter(t *testing.T) {
+	out, err := runSkill(t)
+	require.NoError(t, err)
+
+	require.True(t, strings.HasPrefix(out, "---\n"), "missing opening frontmatter delimiter")
+	assert.Contains(t, out, "name: notes\n")
+	assert.Contains(t, out, "description: Use when ")
+	assert.Contains(t, out, "\n---\n\n")
+}
+
+func TestSkillStdoutDeterministic(t *testing.T) {
+	out1, err := runSkill(t)
+	require.NoError(t, err)
+	out2, err := runSkill(t)
+	require.NoError(t, err)
+	assert.Equal(t, out1, out2, "two invocations must produce byte-identical output")
+}
+
+func TestSkillStdoutListsKnownCommands(t *testing.T) {
+	out, err := runSkill(t)
+	require.NoError(t, err)
+
+	for _, name := range []string{"new", "ls", "read", "append", "annotate", "resolve", "rm", "tags", "update", "config", "skill"} {
+		assert.Contains(t, out, "`notes "+name+"`", "command %s missing from skill body", name)
+	}
+}
+
+func TestSkillStdoutOmitsHelpAndCompletion(t *testing.T) {
+	out, err := runSkill(t)
+	require.NoError(t, err)
+	assert.NotContains(t, out, "`notes help`")
+	assert.NotContains(t, out, "`notes completion`")
+}
+
+func TestSkillStdoutEqualsEmbeddedFile(t *testing.T) {
+	out, err := runSkill(t)
+	require.NoError(t, err)
+	assert.Equal(t, skillContent, out, "stdout output must equal the embedded skill.md byte-for-byte")
+}
+
+func TestSkillStdoutListsPersistentFlags(t *testing.T) {
+	out, err := runSkill(t)
+	require.NoError(t, err)
+	assert.Contains(t, out, "`--path`")
+}
+
+func TestSkillStdoutMentionsStoreLayout(t *testing.T) {
+	out, err := runSkill(t)
+	require.NoError(t, err)
+	assert.Contains(t, out, "NOTES_PATH")
+	assert.Contains(t, out, "YYYY/YYYYMMDD_NNNN.md")
+}
+
+func TestSkillFlagWithoutInstallIsError(t *testing.T) {
+	_, err := runSkill(t, "--agent=claude")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--agent requires --install")
+
+	_, err = runSkill(t, "--force")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--force requires --install")
+
+	_, err = runSkill(t, "--dry-run")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--dry-run requires --install")
+}
+
+func TestSkillUnknownAgent(t *testing.T) {
+	sandboxHome(t, true)
+	_, err := runSkill(t, "--install", "--agent=bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown agent")
+	assert.Contains(t, err.Error(), "claude")
+}
+
+func TestSkillInstallCreate(t *testing.T) {
+	home := sandboxHome(t, true)
+	out, err := runSkill(t, "--install", "--agent=claude")
+	require.NoError(t, err)
+
+	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
+	assert.FileExists(t, target)
+	assert.Contains(t, out, "create")
+	assert.Contains(t, out, target)
+
+	// File content matches stdout mode byte-for-byte.
+	stdoutBytes, err := runSkill(t)
+	require.NoError(t, err)
+	written, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, stdoutBytes, string(written))
+}
+
+func TestSkillInstallSkipOnRerun(t *testing.T) {
+	home := sandboxHome(t, true)
+	_, err := runSkill(t, "--install", "--agent=claude")
+	require.NoError(t, err)
+
+	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
+	beforeStat, err := os.Stat(target)
+	require.NoError(t, err)
+
+	out, err := runSkill(t, "--install", "--agent=claude")
+	require.NoError(t, err)
+	assert.Contains(t, out, "skip")
+
+	afterStat, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, beforeStat.ModTime(), afterStat.ModTime(), "skip must not touch the file")
+}
+
+func TestSkillInstallConflictWithoutForce(t *testing.T) {
+	home := sandboxHome(t, true)
+	_, err := runSkill(t, "--install", "--agent=claude")
+	require.NoError(t, err)
+
+	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
+	require.NoError(t, os.WriteFile(target, []byte("local changes"), 0o644))
+
+	out, err := runSkill(t, "--install", "--agent=claude")
+	require.Error(t, err, "conflict must exit non-zero")
+	assert.Contains(t, out, "conflict")
+
+	current, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "local changes", string(current), "conflict must not write")
+}
+
+func TestSkillInstallForceOverwrites(t *testing.T) {
+	home := sandboxHome(t, true)
+	_, err := runSkill(t, "--install", "--agent=claude")
+	require.NoError(t, err)
+
+	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
+	require.NoError(t, os.WriteFile(target, []byte("local changes"), 0o644))
+
+	out, err := runSkill(t, "--install", "--agent=claude", "--force")
+	require.NoError(t, err)
+	assert.Contains(t, out, "overwrite")
+
+	written, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.NotEqual(t, "local changes", string(written))
+}
+
+func TestSkillInstallDryRun(t *testing.T) {
+	home := sandboxHome(t, true)
+	out, err := runSkill(t, "--install", "--agent=claude", "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, out, "would create")
+
+	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
+	_, statErr := os.Stat(target)
+	assert.True(t, os.IsNotExist(statErr), "dry-run must not write any files")
+}
+
+func TestSkillInstallAutoDetectFindsClaude(t *testing.T) {
+	home := sandboxHome(t, true)
+	out, err := runSkill(t, "--install")
+	require.NoError(t, err)
+	assert.Contains(t, out, "create")
+	assert.Contains(t, out, "claude")
+
+	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
+	assert.FileExists(t, target)
+}
+
+func TestSkillInstallAutoDetectNoneFound(t *testing.T) {
+	sandboxHome(t, false)
+	_, err := runSkill(t, "--install")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no supported agent detected")
+	assert.Contains(t, err.Error(), "claude")
+}
+
+func TestSkillInstallMissingParentDirectoryErrors(t *testing.T) {
+	sandboxHome(t, false) // no ~/.claude/skills
+	_, err := runSkill(t, "--install", "--agent=claude")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent skills directory not found")
+}
+
+func TestSkillInstallMultipleAgents(t *testing.T) {
+	home := sandboxHome(t, true)
+
+	fakeDir := filepath.Join(home, ".fake", "skills")
+	require.NoError(t, os.MkdirAll(fakeDir, 0o755))
+
+	prev := agents
+	agents = append(append([]agentTarget{}, agents...), agentTarget{
+		Name: "fake",
+		PathFor: func() (string, error) {
+			h, err := homeDir()
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(h, ".fake", "skills", "notes", "SKILL.md"), nil
+		},
+		Detect: func() (bool, error) {
+			h, err := homeDir()
+			if err != nil {
+				return false, err
+			}
+			_, statErr := os.Stat(filepath.Join(h, ".fake", "skills"))
+			return statErr == nil, nil
+		},
+	})
+	t.Cleanup(func() { agents = prev })
+
+	out, err := runSkill(t, "--install")
+	require.NoError(t, err)
+	assert.Contains(t, out, "claude")
+	assert.Contains(t, out, "fake")
+	assert.FileExists(t, filepath.Join(home, ".claude", "skills", "notes", "SKILL.md"))
+	assert.FileExists(t, filepath.Join(home, ".fake", "skills", "notes", "SKILL.md"))
+}
+
+func TestSkillHelpDocumentsAgents(t *testing.T) {
+	out, err := runSkill(t, "--help")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Supported --agent values:")
+	assert.Contains(t, out, "claude")
+	assert.Contains(t, out, "~/.claude/skills/notes/SKILL.md")
+}

--- a/internal/cli/skill_test.go
+++ b/internal/cli/skill_test.go
@@ -50,7 +50,7 @@ func TestSkillStdoutHasFrontmatter(t *testing.T) {
 
 	require.True(t, strings.HasPrefix(out, "---\n"), "missing opening frontmatter delimiter")
 	assert.Contains(t, out, "name: notes\n")
-	assert.Contains(t, out, "description: Use when ")
+	assert.Contains(t, out, "description: ")
 	assert.Contains(t, out, "\n---\n\n")
 }
 
@@ -66,8 +66,8 @@ func TestSkillStdoutListsKnownCommands(t *testing.T) {
 	out, err := runSkill(t)
 	require.NoError(t, err)
 
-	for _, name := range []string{"new", "ls", "read", "append", "annotate", "resolve", "rm", "tags", "update", "config", "skill"} {
-		assert.Contains(t, out, "`notes "+name+"`", "command %s missing from skill body", name)
+	for _, name := range []string{"new", "new-todo", "ls", "read", "append", "annotate", "resolve", "rm", "tags", "update", "config", "skill"} {
+		assert.Contains(t, out, "notes "+name, "command %s missing from skill body", name)
 	}
 }
 
@@ -94,7 +94,7 @@ func TestSkillStdoutMentionsStoreLayout(t *testing.T) {
 	out, err := runSkill(t)
 	require.NoError(t, err)
 	assert.Contains(t, out, "NOTES_PATH")
-	assert.Contains(t, out, "YYYY/YYYYMMDD_NNNN.md")
+	assert.Contains(t, out, "YYYY/MM/YYYYMMDD_ID")
 }
 
 func TestSkillFlagWithoutInstallIsError(t *testing.T) {

--- a/specs/001-generate-skill/contracts/cli.md
+++ b/specs/001-generate-skill/contracts/cli.md
@@ -1,0 +1,80 @@
+# Contract: `notes skill` Command Surface
+
+**Branch**: `claude/implement-notes-skill-dOgl8` | **Date**: 2026-05-14
+
+## Synopsis
+
+```text
+notes skill                              # write skill to stdout
+notes skill --install                    # auto-detect agents, install into each
+notes skill --install --agent=<name>     # install into a single named agent
+notes skill --install --force            # overwrite an existing destination
+notes skill --install -n / --dry-run     # print planned actions, write nothing
+```
+
+## Flags
+
+| Flag                | Type   | Modes        | Effect                                                                          |
+|---------------------|--------|--------------|---------------------------------------------------------------------------------|
+| `--install`         | bool   | toggles mode | Switch from stdout mode to install mode.                                        |
+| `--agent <name>`    | string | install only | Install into a single named agent. Default: auto-detect.                        |
+| `--force`           | bool   | install only | Overwrite an existing destination file with diverging content.                  |
+| `-n`, `--dry-run`   | bool   | install only | Print the planned actions but do not write any files.                           |
+
+The persistent `--path` flag inherited from `rootCmd` is accepted (since
+Cobra never rejects unknown persistent flags), but the `skill` command
+does not read it — generating the skill does not depend on a notes store.
+
+## Flag-interaction errors (exit non-zero with `SilenceUsage = true`)
+
+- `--agent` outside of install mode.
+- `--force` outside of install mode.
+- `--dry-run` outside of install mode.
+- `--agent=<unknown>`: error message names the unknown value and lists
+  supported agents.
+- `--install` with `--agent` empty and no agent detected: error message
+  names supported agents and recommends `--agent`.
+
+## Action set (install mode)
+
+See `data-model.md` § `installAction` for the four possible actions
+(`create`, `skip`, `conflict`, `overwrite`) and the decision table.
+
+## Exit codes
+
+- `0` — stdout mode succeeded, or every action is `create`/`skip`/`overwrite`.
+- non-zero — any flag-interaction error; any `conflict` action; any I/O
+  error while reading or writing a destination.
+
+## Human output (install mode)
+
+One line per action:
+
+```text
+<action> <agent> <path>
+```
+
+Examples:
+
+```text
+create   claude  /home/alice/.claude/skills/notes/SKILL.md
+skip     claude  /home/alice/.claude/skills/notes/SKILL.md
+conflict claude  /home/alice/.claude/skills/notes/SKILL.md
+overwrite claude /home/alice/.claude/skills/notes/SKILL.md
+```
+
+For dry-run, the same lines are printed prefixed with `would `:
+
+```text
+would create  claude  /home/alice/.claude/skills/notes/SKILL.md
+```
+
+## Filesystem behaviour
+
+- The command writes exactly one file per selected target.
+- It creates intermediate directories under an existing agent skills
+  directory (e.g. it creates `~/.claude/skills/notes/` if
+  `~/.claude/skills/` exists), but it does NOT create the agent's
+  containing skills directory itself (`~/.claude/skills/`) — that
+  directory's absence is the detection signal that the user does not run
+  this agent.

--- a/specs/001-generate-skill/data-model.md
+++ b/specs/001-generate-skill/data-model.md
@@ -1,0 +1,59 @@
+# Data Model: Generate Agent Skill
+
+**Branch**: `claude/implement-notes-skill-dOgl8` | **Date**: 2026-05-14
+
+In-memory types used by the `notes skill` command. None of these is
+persisted; they exist only for the lifetime of the invocation.
+
+## `skillContent`
+
+The skill document itself is a single embedded string:
+
+```go
+//go:embed skill.md
+var skillContent string
+```
+
+The bytes are read from `internal/cli/skill.md` at compile time. There
+is no in-memory parsing or templating — the file is shipped verbatim,
+including its YAML frontmatter (`name`, `description`) and body.
+
+## `agentTarget`
+
+A supported AI assistant.
+
+```go
+type agentTarget struct {
+    Name    string                  // public flag value, e.g. "claude"
+    PathFor func() (string, error)  // absolute install path
+    Detect  func() (bool, error)    // best-effort presence check
+}
+```
+
+The registry is a package-level `var agents = []agentTarget{...}` slice;
+appending a new entry adds a new agent.
+
+## `installAction`
+
+A single planned filesystem operation against one agent target.
+
+```go
+type installAction struct {
+    Agent  string // agent name
+    Path   string // absolute destination path
+    Action string // "create" | "overwrite" | "skip" | "conflict"
+    Error  error  // populated when planning or applying failed
+}
+```
+
+Action semantics:
+
+- `create` — destination does not exist; will be written.
+- `skip` — destination exists with identical bytes; will not be written.
+- `conflict` — destination exists with different bytes and `--force` is
+  not set; will not be written; contributes a non-zero exit code.
+- `overwrite` — destination exists with different bytes and `--force` is
+  set; will be written.
+
+`Error != nil` short-circuits Action for that target and contributes a
+non-zero exit code regardless of the other actions in the same plan.

--- a/specs/001-generate-skill/plan.md
+++ b/specs/001-generate-skill/plan.md
@@ -1,0 +1,163 @@
+# Implementation Plan: Generate Agent Skill
+
+**Branch**: `claude/implement-notes-skill-dOgl8` | **Date**: 2026-05-14 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Add a `notes skill` Cobra subcommand that, by default, prints a single
+self-contained markdown document (with YAML frontmatter) describing how
+an AI agent should drive the CLI. The document is authored as
+`internal/cli/skill.md` in the repository and embedded into the binary
+at build time via Go's `//go:embed` directive, so the same bytes ship
+with every copy of a given build and the content is reviewed through the
+normal PR review process. The same command, invoked with `--install`,
+writes the embedded skill to one or more agent-specific filesystem
+locations, honouring `--dry-run` and `--force`. The first release
+supports Claude Code (`~/.claude/skills/notes/SKILL.md`); additional
+agent targets are add-only entries in a small in-process registry.
+
+## Technical Context
+
+**Language/Version**: Go 1.25 (per `go.mod`).
+
+**Primary Dependencies**:
+- `github.com/spf13/cobra` — already in use; required for command
+  registration.
+- `embed` (Go standard library) — used via `//go:embed skill.md` to
+  bake the skill into the binary at build time.
+- `github.com/stretchr/testify` — already in use; sufficient for new
+  tests.
+- No new direct dependencies.
+
+**Storage**: None at the data-store level. The command reads only the
+embedded markdown bytes (compiled into the binary). In install mode it
+writes exactly one file per selected agent target under the user's home
+directory; no note-store files are touched.
+
+**Testing**: Tests live in `internal/cli/skill_test.go`. Filesystem tests
+use `t.TempDir()` and override the package-level home-dir resolver to
+avoid touching the real `~/.claude`.
+
+**Target Platform**: macOS and Linux, anywhere Go 1.25 builds.
+
+**Project Type**: Single-project Go CLI tool.
+
+**Constraints**:
+- **Deterministic output**: two invocations on the same binary in the
+  same environment MUST produce byte-identical skill content. Implies:
+  stable iteration order over commands and flags, no timestamps in
+  output.
+- **No network access.** The skill is generated locally.
+- **No writes outside the explicit install target.** Stdout mode is a
+  pure function; install mode writes exactly one file per target.
+
+**Scope**: One new top-level subcommand. Estimated footprint: ~1 new
+markdown source `internal/cli/skill.md`, ~1 new Go file
+`internal/cli/skill.go`, ~1 new test file `internal/cli/skill_test.go`,
+plus a one-line `CHANGELOG.md` entry and a short README section.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-generate-skill/
+├── plan.md              # This file
+├── spec.md              # User-facing specification
+├── data-model.md        # In-memory types
+├── quickstart.md        # Contributor smoke-tests
+└── contracts/
+    └── cli.md           # Command-surface contract: flags, exit codes, action set
+```
+
+### Source Code (repository root)
+
+```text
+cmd/
+└── notes/
+    └── main.go                       # unchanged — entrypoint delegates to internal/cli
+
+internal/
+└── cli/
+    ├── root.go                       # unchanged
+    ├── skill.md                      # NEW — authored skill content, embedded into the binary
+    ├── skill.go                      # NEW — command def, install(), agent registry
+    ├── skill_test.go                 # NEW — tests for stdout/install/dry-run/force
+    └── …                             # other existing files unchanged
+```
+
+**Structure Decision**: Single-project layout, matches the existing
+`internal/cli/<command>.go` per-command convention. The skill renderer,
+agent registry, and Cobra handler all live in `internal/cli/skill.go`
+because they share the same data (Cobra's command tree).
+
+## Design Decisions
+
+### How is the skill content authored and shipped?
+
+The skill is a hand-authored markdown file at `internal/cli/skill.md`,
+including its YAML frontmatter block. The Go file declares:
+
+```go
+//go:embed skill.md
+var skillContent string
+```
+
+At build time the markdown bytes are baked into the binary, so the
+runtime cost is zero and the bytes emitted are byte-identical across
+machines. Editing the skill is a one-file PR; no code changes are
+required to update wording, structure, or examples.
+
+### What is the structure of the skill body?
+
+Authored as five sections inside `skill.md`:
+
+1. **Overview** — one paragraph: what `notes` does, its store model.
+2. **Global flags** — list of persistent flags (`--path`).
+3. **Commands** — bullet list of subcommands with their `Short` blurbs,
+   pointing the reader at `notes <name> --help` for the full flag set.
+4. **Store layout** — short paragraph describing how `NOTES_PATH`
+   resolves and the on-disk format (`YYYY/YYYYMMDD_NNNN.md` with YAML
+   frontmatter).
+5. **Composing with the shell** — short paragraph showing the
+   `ls`/`resolve` → ID pattern that lets `read`, `append`, `update`,
+   `rm`, `annotate` chain together.
+
+### Keeping the skill in sync with the CLI
+
+Because the skill is authored, not generated, an out-of-date skill is a
+review concern. The acceptance scenario for keeping the document in sync
+with new commands is "the author of a new command updates `skill.md` in
+the same PR." Tests assert that the embedded content is non-empty,
+starts with the expected frontmatter, and lists a known core set of
+commands.
+
+### How are agent install locations represented?
+
+A small `[]agentTarget` slice declared in `internal/cli/skill.go`. Each
+entry has `Name string`, `PathFor func() (string, error)`, and
+`Detect func() (bool, error)`. Adding a new agent is one append.
+
+### Detection signal
+
+For Claude Code, the agent is considered "detected" when the directory
+`~/.claude/skills/` exists on the machine. Cheap, side-effect-free, and
+uses only `os.Stat`. We do not probe `$PATH` for a `claude` binary
+(the name collides with too much else).
+
+### How does install mode decide between Create / Overwrite / Skip / Conflict?
+
+| Existing file? | Bytes equal to generated skill? | `--force`? | Action      | Writes? | Exit |
+|----------------|---------------------------------|------------|-------------|---------|------|
+| No             | —                               | —          | `create`    | yes     | 0    |
+| Yes            | Yes                             | —          | `skip`      | no      | 0    |
+| Yes            | No                              | No         | `conflict`  | no      | ≠ 0  |
+| Yes            | No                              | Yes        | `overwrite` | yes     | 0    |
+
+`--dry-run` reports the action without writing.
+
+### How are filesystem paths under `~` resolved in tests?
+
+Provide a package-level `homeDir func() (string, error)` defaulting to
+`os.UserHomeDir`. Tests assign a stub that returns `t.TempDir()` and
+reset it via `t.Cleanup`.

--- a/specs/001-generate-skill/quickstart.md
+++ b/specs/001-generate-skill/quickstart.md
@@ -1,0 +1,86 @@
+# Quickstart: Generate Agent Skill
+
+**Branch**: `claude/implement-notes-skill-dOgl8` | **Date**: 2026-05-14
+
+Local instructions for building, testing, and exercising the new
+`notes skill` command.
+
+## Build
+
+```sh
+make build         # produces ./notes bound to the current git tag
+./notes --help     # confirm the new "skill" subcommand is listed
+```
+
+## Smoke-test stdout mode
+
+```sh
+./notes skill | head -40                       # human/plain output
+./notes skill --help                            # documents flags
+diff <(./notes skill) <(./notes skill)          # MUST be empty (determinism)
+```
+
+## Smoke-test install mode against a sandbox HOME
+
+Avoid touching the real `~/.claude`. Use a tempdir as HOME:
+
+```sh
+SANDBOX=$(mktemp -d)
+mkdir -p "$SANDBOX/.claude/skills"  # signal Claude Code is "installed"
+
+# Auto-detect mode
+HOME="$SANDBOX" ./notes skill --install
+# Expect: create claude  $SANDBOX/.claude/skills/notes/SKILL.md
+
+# Re-run: should be a no-op (byte-identical)
+HOME="$SANDBOX" ./notes skill --install
+# Expect: skip claude ...
+
+# Mutate the file and re-run without --force: conflict
+echo CHANGED >> "$SANDBOX/.claude/skills/notes/SKILL.md"
+HOME="$SANDBOX" ./notes skill --install
+# Expect: conflict, process exit non-zero
+
+# Re-run with --force: overwrites
+HOME="$SANDBOX" ./notes skill --install --force
+# Expect: overwrite, exit 0
+
+# Dry-run never writes
+rm "$SANDBOX/.claude/skills/notes/SKILL.md"
+HOME="$SANDBOX" ./notes skill --install --dry-run
+# Expect: would create ...
+test ! -e "$SANDBOX/.claude/skills/notes/SKILL.md"   # nothing written
+```
+
+## Smoke-test agent selection and error paths
+
+```sh
+HOME="$SANDBOX" ./notes skill --install --agent=claude    # explicit OK
+HOME="$SANDBOX" ./notes skill --install --agent=bogus     # error: unknown agent
+./notes skill --force                                       # usage error (no --install)
+HOME=$(mktemp -d) ./notes skill --install                   # no agents detected → error
+```
+
+## Run the test suite
+
+```sh
+make test
+make lint
+```
+
+Both MUST pass before pushing or opening the PR.
+
+## Inspect what the skill says
+
+```sh
+./notes skill | less
+```
+
+The body should contain:
+
+- An Overview paragraph naming the binary.
+- A Global Flags section with `--path`.
+- A Commands table with one row per available subcommand, alphabetised.
+- A Store layout section pointing at `NOTES_PATH` and the
+  `YYYY/YYYYMMDD_NNNN.md` file layout.
+- A shell-composition section showing the `ls`/`resolve` → ID pattern.

--- a/specs/001-generate-skill/spec.md
+++ b/specs/001-generate-skill/spec.md
@@ -1,0 +1,200 @@
+# Feature Specification: Generate Agent Skill
+
+**Feature Branch**: `claude/implement-notes-skill-dOgl8`
+
+**Created**: 2026-05-14
+
+**Status**: Draft
+
+**Input**: User request — "Implement `notes skill` feature" following the
+pattern of `dotfiles-cli/specs/001-generate-skill`.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Print the skill to stdout (Priority: P1) — MVP
+
+As a user (human or agent) of an AI coding assistant, I want a single
+command that emits a ready-to-use *skill* describing how to drive `notes`,
+so that my assistant can learn the CLI's surface, conventions, and store
+layout from one authoritative document instead of guessing from `--help`
+output piecemeal.
+
+**Why this priority**: Standalone value. With only stdout output, a user
+can pipe the result anywhere — into a file, a clipboard tool, an agent
+configuration, or a chat message. Every later story builds on this
+content.
+
+**Independent Test**: Run `notes skill` on a fresh install. Confirm the
+output is a single self-contained markdown document, beginning with a YAML
+frontmatter block (`name`, `description`), and that the body covers every
+top-level subcommand of the CLI and the global flags. Nothing else is
+written to disk.
+
+**Acceptance Scenarios**:
+
+1. **Given** a working `notes` binary, **When** the user runs
+   `notes skill`, **Then** a single markdown document is printed to stdout
+   and the process exits with status `0`.
+2. **Given** the same binary, **When** the user runs `notes skill --help`,
+   **Then** the help text documents the command and its flags.
+3. **Given** the binary is rebuilt, **When** the user runs `notes skill`
+   on two different machines, **Then** both invocations emit byte-identical
+   output, because the skill content is embedded into the binary at build
+   time from a versioned markdown source.
+
+---
+
+### User Story 2 — Install the skill into a known agent location (Priority: P2)
+
+As a user who already runs an AI coding assistant locally, I want a single
+command that drops the skill into the assistant's well-known skills
+directory, so that I don't have to know where the directory lives, what
+filename to use, or how to format the frontmatter.
+
+**Independent Test**: On a machine where the target agent's skills
+directory exists, run `notes skill --install --agent=<name>`. Confirm a
+single file is created at the agent's documented skill location, its
+content matches `notes skill` exactly, and the command reports the
+destination path.
+
+**Acceptance Scenarios**:
+
+1. **Given** the target agent's skills directory exists and no skill file
+   is present, **When** the user runs `notes skill --install --agent=<name>`,
+   **Then** the skill file is created at the agent-specific path and the
+   command prints the destination path.
+2. **Given** a skill file already exists at the target path with identical
+   content, **When** the user re-runs the same command, **Then** no file
+   is modified and the action is reported as `skip`.
+3. **Given** a skill file already exists with different content, **When**
+   the user runs without `--force`, **Then** no file is modified, the
+   command exits non-zero, and the message identifies the conflict.
+4. **Given** the same precondition, **When** the user adds `--force`,
+   **Then** the existing file is overwritten and the action is reported.
+5. **Given** any of the above, **When** the user adds `-n, --dry-run`,
+   **Then** the command prints the action it *would* take and writes
+   nothing to disk.
+6. **Given** the user passes `--agent` with an unknown value, **Then** the
+   command exits non-zero with an error naming the unknown agent and
+   listing the supported values.
+
+---
+
+### User Story 3 — Auto-detect installed agents (Priority: P3)
+
+As a user who has more than one AI assistant installed, I want
+`notes skill --install` (without `--agent`) to discover which assistants
+are present on this machine and install the skill into each one.
+
+**Independent Test**: On a machine where a supported agent is installed,
+run `notes skill --install`. Confirm the skill is created in the agent's
+skill directory. On a machine with no supported agents detected, confirm
+the command exits non-zero with an actionable error.
+
+**Acceptance Scenarios**:
+
+1. **Given** at least one supported agent is detected on the machine,
+   **When** the user runs `notes skill --install`, **Then** the skill is
+   installed into every detected agent's location and each destination
+   path is reported.
+2. **Given** no supported agent is detected, **When** the same command is
+   run, **Then** the command exits non-zero with a message listing
+   supported agents and how to pass `--agent` explicitly.
+3. **Given** auto-detect mode, **When** the skill already exists in some
+   locations but not others, **Then** without `--force` the command
+   installs into empty locations and reports the conflicts in the
+   already-populated locations.
+
+---
+
+### Edge Cases
+
+- The skill content references the binary's version; a stale binary
+  prints a stale skill. Users opt in to refresh by re-running.
+- The target agent directory's parent (`~/.claude/skills/`) does not
+  exist: the command exits non-zero with a message explaining the missing
+  directory; it does not create unfamiliar parent directories.
+- The user's home directory is not writable: the install mode surfaces
+  the OS error and exits non-zero.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The CLI MUST provide a `notes skill` command exposed as a
+  top-level subcommand alongside the existing commands.
+- **FR-002**: Invoked with no extra arguments, the command MUST write the
+  skill content to stdout as a single markdown document and MUST NOT
+  modify the filesystem.
+- **FR-003**: The skill content MUST begin with a YAML frontmatter block
+  containing at minimum a `name` field and a `description` field that
+  follows the convention "Use when …" so AI agents can match it to a
+  task.
+- **FR-004**: The skill body MUST cover, at minimum: every top-level
+  subcommand and its purpose; the global `--path` flag; the role of
+  `NOTES_PATH`; the note store layout (date-stamped folders, markdown
+  files with YAML frontmatter); and a pointer to `notes <command> --help`
+  as the authoritative source for each command's full flag list.
+- **FR-005**: The skill content MUST be authored as a markdown file
+  checked into the repository and embedded into the binary at build time
+  (via Go's `//go:embed` directive), so the same bytes ship with every
+  copy of a given build and the content lives under normal source
+  control.
+- **FR-006**: The command MUST accept an `--install` flag that, when
+  present, switches the command from stdout mode to filesystem mode.
+- **FR-007**: In install mode, the command MUST accept an optional
+  `--agent=<name>` flag selecting the destination. Supported `<name>`
+  values MUST be enumerated in `--help`.
+- **FR-008**: In install mode without `--agent`, the command MUST attempt
+  to auto-detect installed agents from a known list and install into
+  every detected agent's location. If none is detected, the command MUST
+  exit non-zero with an actionable error.
+- **FR-009**: In install mode, the command MUST refuse to overwrite an
+  existing destination file unless `--force` is passed.
+- **FR-010**: In install mode, the command MUST support `-n, --dry-run`,
+  which prints the actions it would take and writes nothing.
+- **FR-011**: In install mode, the command MUST report each destination
+  path on success.
+
+### Key Entities
+
+- **Skill**: a self-contained markdown document with YAML frontmatter
+  describing how an AI agent should drive the `notes` CLI. There is
+  exactly one skill per `notes` binary.
+- **Agent target**: a named AI assistant (initially Claude Code) that has
+  a documented filesystem location for user-installed skills.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: A user who has never read the README can install the skill
+  into their AI assistant in a single command, and the assistant can then
+  perform note creation, listing, and reading workflows correctly on the
+  first attempt.
+- **SC-002**: The skill output contains an entry for 100% of the commands
+  listed by `notes --help`; no command is silently omitted.
+- **SC-003**: Re-running `notes skill --install` without `--force`
+  against an unchanged target is a no-op. Re-running with `--force`
+  produces a destination file byte-for-byte equal to the stdout output of
+  `notes skill` on the same binary.
+- **SC-004**: The skill source is a single markdown file in the
+  repository, reviewable via normal PR review. Updating the skill is a
+  one-file change with no code edits required.
+
+## Assumptions
+
+- Initial agent support is Claude Code only. The `--agent=claude` target
+  ships in the first version, and auto-detect initially looks for that
+  one agent. Additional agents are added in follow-up work.
+- The Claude Code skill location is `~/.claude/skills/notes/SKILL.md`.
+- The skill content is generated at runtime from the same command
+  registry that powers `--help`, so version drift between the binary and
+  the skill content is impossible by construction.
+
+## Dependencies
+
+- The CLI's existing Cobra command registry must expose each command's
+  name, short description, and flag list (it already does — that's what
+  `--help` reads).
+- The destination directory for the Claude Code agent
+  (`~/.claude/skills/notes/`) must be created on demand only when the
+  user passes `--install`.


### PR DESCRIPTION
## Summary

Implements the `notes skill` command, which generates a self-contained markdown document describing how an AI assistant should drive the notes CLI. The skill is authored as `internal/cli/skill.md` and embedded into the binary at build time via Go's `//go:embed` directive.

**Default behavior** (`notes skill`): prints the skill to stdout as a single markdown document with YAML frontmatter.

**Install mode** (`notes skill --install`): writes the skill to one or more agent-specific filesystem locations:
- Auto-detects installed agents (currently Claude Code at `~/.claude/skills/notes/SKILL.md`)
- Supports explicit agent selection via `--agent=<name>`
- Respects `--force` to overwrite existing files with diverging content
- Supports `--dry-run` to preview actions without writing
- Reports each action (create, skip, conflict, overwrite) with destination paths
- Exits non-zero on conflicts or I/O errors

The skill content covers all top-level subcommands, global flags, store layout, and shell composition patterns. Because the skill is embedded at build time, the same bytes ship with every copy of a given build, ensuring deterministic output across machines.

## Changes

- **`internal/cli/skill.md`** (new): Hand-authored skill document with YAML frontmatter and comprehensive CLI documentation
- **`internal/cli/skill.go`** (new): Command implementation with agent registry, install planning, and filesystem operations
- **`internal/cli/skill_test.go`** (new): 16 test cases covering stdout mode, install mode, auto-detection, conflict handling, dry-run, and error paths
- **`README.md`**: Added examples of `notes skill` usage
- **`CHANGELOG.md`**: Documented new feature under `[0.4.1]`
- **`specs/001-generate-skill/`** (new): Complete specification, implementation plan, data model, CLI contract, and quickstart guide

## Testing

All 16 new unit tests pass, covering:
- Stdout mode determinism and content validation
- Install mode with create, skip, conflict, and overwrite actions
- Auto-detection of installed agents
- Dry-run mode (no filesystem writes)
- Force flag behavior
- Error handling for unknown agents and missing directories
- Multiple agent installation

Tests use `t.TempDir()` and override the home-dir resolver to avoid touching the real filesystem.
