### PR TITLE
Add codex, pi, and agents skill install targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-14
+
+### Added
+
+- `notes skill --install` now supports two additional install targets alongside `claude`: `pi` (writes to `~/.pi/agent/skills/notes/SKILL.md`) and `agents` (writes to `~/.agents/skills/notes/SKILL.md`, the cross-harness convention read by Codex, Cursor, OpenCode, Pi, VS Code Copilot, Warp, and others). All targets share the [Agent Skills](https://agentskills.io/specification) `SKILL.md` format. Auto-detect installs into every target whose skills-root directory exists; pass `--target=<name>` to install into a single one. The `--agent` flag is renamed to `--target` since each target names a filesystem location, not an agent — multiple harnesses read the same location.
+
 ## [0.4.1] - 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ notes config
 
 # Print an AI-assistant skill describing how to drive notes
 notes skill
-notes skill --install                # auto-detect agents, install into each
-notes skill --install --agent=claude # install into a specific agent
-notes skill --install --dry-run      # show planned actions, write nothing
-notes skill --install --force        # overwrite a diverging existing skill
+notes skill --install                 # auto-detect skills roots, install into each
+notes skill --install --target=claude # install into a specific target (claude, pi, agents)
+notes skill --install --dry-run       # show planned actions, write nothing
+notes skill --install --force         # overwrite a diverging existing skill
 ```
 
 Composing with the shell — since most commands take an ID, use `ls` or

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -21,45 +21,72 @@ var skillContent string
 // redirected to a temporary directory.
 var homeDir = os.UserHomeDir
 
-// agentTarget is a supported AI assistant. The registry is the package
-// variable agents below; new entries are added by appending.
-type agentTarget struct {
+// installTarget is a supported skills-root location. Each target maps to
+// one filesystem destination; multiple AI agents may read from the same
+// destination (notably ~/.agents/skills/, which is read by Codex,
+// Cursor, OpenCode, Pi, VS Code Copilot, Warp, and others).
+//
+// RootDir is the directory whose existence indicates the user actually
+// uses a harness that reads this location. It is the only directory
+// the install path may not create — if it is missing, the install fails
+// with an actionable error rather than materialising an unfamiliar
+// dotdir. Subdirectories between RootDir and PathFor are created on
+// demand.
+type installTarget struct {
 	Name    string
 	PathFor func() (string, error)
-	Detect  func() (bool, error)
+	RootDir func() (string, error)
 }
 
-var agents = []agentTarget{
+func underHome(parts ...string) func() (string, error) {
+	return func() (string, error) {
+		home, err := homeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(append([]string{home}, parts...)...), nil
+	}
+}
+
+var targets = []installTarget{
 	{
-		Name: "claude",
-		PathFor: func() (string, error) {
-			home, err := homeDir()
-			if err != nil {
-				return "", err
-			}
-			return filepath.Join(home, ".claude", "skills", "notes", "SKILL.md"), nil
-		},
-		Detect: func() (bool, error) {
-			home, err := homeDir()
-			if err != nil {
-				return false, err
-			}
-			_, err = os.Stat(filepath.Join(home, ".claude", "skills"))
-			if err == nil {
-				return true, nil
-			}
-			if errors.Is(err, os.ErrNotExist) {
-				return false, nil
-			}
-			return false, err
-		},
+		Name:    "claude",
+		PathFor: underHome(".claude", "skills", "notes", "SKILL.md"),
+		RootDir: underHome(".claude", "skills"),
+	},
+	{
+		Name:    "pi",
+		PathFor: underHome(".pi", "agent", "skills", "notes", "SKILL.md"),
+		RootDir: underHome(".pi", "agent", "skills"),
+	},
+	{
+		Name:    "agents",
+		PathFor: underHome(".agents", "skills", "notes", "SKILL.md"),
+		RootDir: underHome(".agents", "skills"),
 	},
 }
 
+// Detect reports whether the target appears to be in use on this
+// machine, using only os.Stat on the declared RootDir.
+func (t installTarget) Detect() (bool, error) {
+	dir, err := t.RootDir()
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(dir)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
 // installAction is a single planned filesystem operation against one
-// agent target. See specs/001-generate-skill/data-model.md.
+// target. See specs/001-generate-skill/data-model.md.
 type installAction struct {
-	Agent  string
+	Target string
 	Path   string
 	Action string
 	Error  error
@@ -74,7 +101,7 @@ const (
 
 var (
 	skillInstall bool
-	skillAgent   string
+	skillTarget  string
 	skillForce   bool
 	skillDryRun  bool
 )
@@ -87,11 +114,23 @@ agent should drive the notes CLI. The skill is authored as a markdown
 file in the repository and embedded into the binary at build time, so
 the same bytes are emitted across machines.
 
-With --install, the skill is written to a known per-agent location
-instead of stdout. Supported agents are listed below.
+With --install, the skill is written to a known skills-root location
+instead of stdout. Each target names a filesystem destination, not an
+agent — multiple harnesses read from the same locations.
 
-Supported --agent values:
+Supported --target values:
   claude    ~/.claude/skills/notes/SKILL.md
+            Read by: Claude Code
+  pi        ~/.pi/agent/skills/notes/SKILL.md
+            Read by: Pi
+  agents    ~/.agents/skills/notes/SKILL.md
+            Read by: Codex, Cursor, OpenCode, Pi, VS Code Copilot, Warp,
+            and other harnesses adopting the cross-harness convention
+
+All targets receive the same SKILL.md body (the format is the Agent
+Skills standard, https://agentskills.io/specification). A target is
+"detected" when its skills root directory exists. Without --target,
+--install writes to every detected target.
 
 Actions (install mode):
   create     destination did not exist; written
@@ -112,12 +151,12 @@ func skillRunE(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	targets, err := resolveTargets()
+	resolved, err := resolveTargets()
 	if err != nil {
 		return err
 	}
 
-	actions := planInstall(skillContent, targets)
+	actions := planInstall(skillContent, resolved)
 	if err := applyInstall(actions, skillDryRun); err != nil {
 		return err
 	}
@@ -128,57 +167,57 @@ func skillRunE(cmd *cobra.Command, _ []string) error {
 func validateSkillFlags() error {
 	if !skillInstall {
 		switch {
-		case skillAgent != "":
-			return errors.New("--agent requires --install")
+		case skillTarget != "":
+			return errors.New("--target requires --install")
 		case skillForce:
 			return errors.New("--force requires --install")
 		case skillDryRun:
 			return errors.New("--dry-run requires --install")
 		}
 	}
-	if skillAgent != "" && findAgent(skillAgent) == nil {
-		return fmt.Errorf("unknown agent %q (supported: %s)", skillAgent, agentNamesList())
+	if skillTarget != "" && findTarget(skillTarget) == nil {
+		return fmt.Errorf("unknown target %q (supported: %s)", skillTarget, targetNamesList())
 	}
 	return nil
 }
 
-func findAgent(name string) *agentTarget {
-	for i := range agents {
-		if agents[i].Name == name {
-			return &agents[i]
+func findTarget(name string) *installTarget {
+	for i := range targets {
+		if targets[i].Name == name {
+			return &targets[i]
 		}
 	}
 	return nil
 }
 
-func agentNamesList() string {
-	names := make([]string, len(agents))
-	for i, a := range agents {
-		names[i] = a.Name
+func targetNamesList() string {
+	names := make([]string, len(targets))
+	for i, t := range targets {
+		names[i] = t.Name
 	}
 	sort.Strings(names)
 	return strings.Join(names, ", ")
 }
 
-// resolveTargets returns the agent targets to act on for the current
-// invocation: either the single agent named by --agent, or every detected
-// agent when --agent is empty.
-func resolveTargets() ([]agentTarget, error) {
-	if skillAgent != "" {
-		return []agentTarget{*findAgent(skillAgent)}, nil
+// resolveTargets returns the targets to act on for the current
+// invocation: either the single target named by --target, or every
+// detected target when --target is empty.
+func resolveTargets() ([]installTarget, error) {
+	if skillTarget != "" {
+		return []installTarget{*findTarget(skillTarget)}, nil
 	}
-	var detected []agentTarget
-	for _, a := range agents {
-		ok, err := a.Detect()
+	var detected []installTarget
+	for _, t := range targets {
+		ok, err := t.Detect()
 		if err != nil {
 			return nil, err
 		}
 		if ok {
-			detected = append(detected, a)
+			detected = append(detected, t)
 		}
 	}
 	if len(detected) == 0 {
-		return nil, fmt.Errorf("no supported agent detected; pass --agent explicitly (supported: %s)", agentNamesList())
+		return nil, fmt.Errorf("no supported target detected; pass --target explicitly (supported: %s)", targetNamesList())
 	}
 	return detected, nil
 }
@@ -187,7 +226,7 @@ func resolveTargets() ([]agentTarget, error) {
 // anything. An OS error while reading an existing destination is
 // captured in the action's Error field rather than aborting the whole
 // plan.
-func planInstall(content string, targets []agentTarget) []installAction {
+func planInstall(content string, targets []installTarget) []installAction {
 	bytesContent := []byte(content)
 	actions := make([]installAction, len(targets))
 	for i, t := range targets {
@@ -196,25 +235,33 @@ func planInstall(content string, targets []agentTarget) []installAction {
 	return actions
 }
 
-func planOne(t agentTarget, content []byte) installAction {
+func planOne(t installTarget, content []byte) installAction {
+	detected, err := t.Detect()
+	if err != nil {
+		return installAction{Target: t.Name, Error: err}
+	}
+	if !detected {
+		root, _ := t.RootDir()
+		return installAction{Target: t.Name, Error: fmt.Errorf("skills root directory not found: %s", root)}
+	}
 	path, err := t.PathFor()
 	if err != nil {
-		return installAction{Agent: t.Name, Error: err}
+		return installAction{Target: t.Name, Error: err}
 	}
 	existing, err := os.ReadFile(path)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
-		return installAction{Agent: t.Name, Path: path, Action: actionCreate}
+		return installAction{Target: t.Name, Path: path, Action: actionCreate}
 	case err != nil:
-		return installAction{Agent: t.Name, Path: path, Error: err}
+		return installAction{Target: t.Name, Path: path, Error: err}
 	}
 	if string(existing) == string(content) {
-		return installAction{Agent: t.Name, Path: path, Action: actionSkip}
+		return installAction{Target: t.Name, Path: path, Action: actionSkip}
 	}
 	if skillForce {
-		return installAction{Agent: t.Name, Path: path, Action: actionOverwrite}
+		return installAction{Target: t.Name, Path: path, Action: actionOverwrite}
 	}
-	return installAction{Agent: t.Name, Path: path, Action: actionConflict}
+	return installAction{Target: t.Name, Path: path, Action: actionConflict}
 }
 
 // applyInstall performs the writes implied by the action plan. In
@@ -239,24 +286,12 @@ func applyInstall(actions []installAction, dryRun bool) error {
 	return nil
 }
 
-// writeSkillFile creates the parent directory if its parent already
-// exists (e.g. creates ~/.claude/skills/notes/ when ~/.claude/skills/
-// exists), but refuses to materialise an absent agent skills directory.
-// That absence is the detection signal that the user does not run this
-// agent.
+// writeSkillFile materialises any missing intermediate directories under
+// the target's already-existing root directory and writes the file.
+// planOne guarantees the target's RootDir exists before this is called.
 func writeSkillFile(path string, content []byte) error {
-	parent := filepath.Dir(path)
-	if _, err := os.Stat(parent); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return err
-		}
-		grandparent := filepath.Dir(parent)
-		if _, gerr := os.Stat(grandparent); gerr != nil {
-			return fmt.Errorf("agent skills directory not found: %s", grandparent)
-		}
-		if err := os.MkdirAll(parent, 0o755); err != nil {
-			return err
-		}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
 	}
 	return os.WriteFile(path, content, 0o644)
 }
@@ -265,14 +300,14 @@ func printActions(out io.Writer, actions []installAction, dryRun bool) {
 	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	for _, a := range actions {
 		if a.Error != nil {
-			fmt.Fprintf(w, "error\t%s\t%s\n", a.Agent, a.Error)
+			fmt.Fprintf(w, "error\t%s\t%s\n", a.Target, a.Error)
 			continue
 		}
 		verb := a.Action
 		if dryRun {
 			verb = "would " + verb
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\n", verb, a.Agent, a.Path)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", verb, a.Target, a.Path)
 	}
 	_ = w.Flush()
 }
@@ -282,9 +317,9 @@ func exitErrorFor(actions []installAction) error {
 	for _, a := range actions {
 		switch {
 		case a.Error != nil:
-			problems = append(problems, fmt.Sprintf("%s: %s", a.Agent, a.Error))
+			problems = append(problems, fmt.Sprintf("%s: %s", a.Target, a.Error))
 		case a.Action == actionConflict:
-			problems = append(problems, fmt.Sprintf("%s: destination exists with different content; pass --force to overwrite", a.Agent))
+			problems = append(problems, fmt.Sprintf("%s: destination exists with different content; pass --force to overwrite", a.Target))
 		}
 	}
 	if len(problems) == 0 {
@@ -294,8 +329,8 @@ func exitErrorFor(actions []installAction) error {
 }
 
 func registerSkillFlags() {
-	skillCmd.Flags().BoolVar(&skillInstall, "install", false, "install the skill into one or more agent locations")
-	skillCmd.Flags().StringVar(&skillAgent, "agent", "", "install only into the named agent (default: auto-detect)")
+	skillCmd.Flags().BoolVar(&skillInstall, "install", false, "install the skill into one or more skills-root locations")
+	skillCmd.Flags().StringVar(&skillTarget, "target", "", "install only into the named target (default: auto-detect)")
 	skillCmd.Flags().BoolVar(&skillForce, "force", false, "overwrite an existing destination with diverging content")
 	skillCmd.Flags().BoolVarP(&skillDryRun, "dry-run", "n", false, "print planned actions but do not write any files")
 }

--- a/internal/cli/skill.md
+++ b/internal/cli/skill.md
@@ -170,11 +170,17 @@ Prints the resolved store path, default values for per-command flags, and the pr
 
 ```sh
 notes skill                              # print this skill to stdout
-notes skill --install                    # write into every detected agent's skills directory
-notes skill --install --agent=claude     # explicit single-agent install
+notes skill --install                    # write into every detected skills-root location
+notes skill --install --target=claude    # explicit single-location install
 notes skill --install --force            # overwrite an existing diverging copy
 notes skill --install --dry-run          # print planned actions, write nothing
 ```
+
+All targets share the [Agent Skills](https://agentskills.io/specification) format. Supported `--target` values:
+
+- `claude` → `~/.claude/skills/notes/SKILL.md` (read by Claude Code)
+- `pi` → `~/.pi/agent/skills/notes/SKILL.md` (read by Pi)
+- `agents` → `~/.agents/skills/notes/SKILL.md` (cross-harness convention read by Codex, Cursor, OpenCode, Pi, VS Code Copilot, Warp, and others)
 
 ## Editing Notes
 

--- a/internal/cli/skill_test.go
+++ b/internal/cli/skill_test.go
@@ -17,7 +17,7 @@ func runSkill(t *testing.T, args ...string) (string, error) {
 	skillCmd.ResetFlags()
 	registerSkillFlags()
 	skillInstall = false
-	skillAgent = ""
+	skillTarget = ""
 	skillForce = false
 	skillDryRun = false
 
@@ -31,16 +31,23 @@ func runSkill(t *testing.T, args ...string) (string, error) {
 }
 
 // sandboxHome redirects the package-level homeDir resolver to a fresh
-// tempdir for the lifetime of the test. Returns the sandbox path.
-func sandboxHome(t *testing.T, withClaudeSkills bool) string {
+// tempdir for the lifetime of the test. Any target names passed in
+// installed have their RootDir() materialised inside the sandbox so
+// Detect() succeeds for them.
+func sandboxHome(t *testing.T, installed ...string) string {
 	t.Helper()
 	dir := t.TempDir()
-	if withClaudeSkills {
-		require.NoError(t, os.MkdirAll(filepath.Join(dir, ".claude", "skills"), 0o755))
-	}
 	prev := homeDir
 	homeDir = func() (string, error) { return dir, nil }
 	t.Cleanup(func() { homeDir = prev })
+
+	for _, name := range installed {
+		tg := findTarget(name)
+		require.NotNil(t, tg, "unknown target %q", name)
+		root, err := tg.RootDir()
+		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(root, 0o755))
+	}
 	return dir
 }
 
@@ -98,9 +105,9 @@ func TestSkillStdoutMentionsStoreLayout(t *testing.T) {
 }
 
 func TestSkillFlagWithoutInstallIsError(t *testing.T) {
-	_, err := runSkill(t, "--agent=claude")
+	_, err := runSkill(t, "--target=claude")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--agent requires --install")
+	assert.Contains(t, err.Error(), "--target requires --install")
 
 	_, err = runSkill(t, "--force")
 	require.Error(t, err)
@@ -111,17 +118,17 @@ func TestSkillFlagWithoutInstallIsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "--dry-run requires --install")
 }
 
-func TestSkillUnknownAgent(t *testing.T) {
-	sandboxHome(t, true)
-	_, err := runSkill(t, "--install", "--agent=bogus")
+func TestSkillUnknownTarget(t *testing.T) {
+	sandboxHome(t, "claude")
+	_, err := runSkill(t, "--install", "--target=bogus")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown agent")
+	assert.Contains(t, err.Error(), "unknown target")
 	assert.Contains(t, err.Error(), "claude")
 }
 
 func TestSkillInstallCreate(t *testing.T) {
-	home := sandboxHome(t, true)
-	out, err := runSkill(t, "--install", "--agent=claude")
+	home := sandboxHome(t, "claude")
+	out, err := runSkill(t, "--install", "--target=claude")
 	require.NoError(t, err)
 
 	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
@@ -138,15 +145,15 @@ func TestSkillInstallCreate(t *testing.T) {
 }
 
 func TestSkillInstallSkipOnRerun(t *testing.T) {
-	home := sandboxHome(t, true)
-	_, err := runSkill(t, "--install", "--agent=claude")
+	home := sandboxHome(t, "claude")
+	_, err := runSkill(t, "--install", "--target=claude")
 	require.NoError(t, err)
 
 	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
 	beforeStat, err := os.Stat(target)
 	require.NoError(t, err)
 
-	out, err := runSkill(t, "--install", "--agent=claude")
+	out, err := runSkill(t, "--install", "--target=claude")
 	require.NoError(t, err)
 	assert.Contains(t, out, "skip")
 
@@ -156,14 +163,14 @@ func TestSkillInstallSkipOnRerun(t *testing.T) {
 }
 
 func TestSkillInstallConflictWithoutForce(t *testing.T) {
-	home := sandboxHome(t, true)
-	_, err := runSkill(t, "--install", "--agent=claude")
+	home := sandboxHome(t, "claude")
+	_, err := runSkill(t, "--install", "--target=claude")
 	require.NoError(t, err)
 
 	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
 	require.NoError(t, os.WriteFile(target, []byte("local changes"), 0o644))
 
-	out, err := runSkill(t, "--install", "--agent=claude")
+	out, err := runSkill(t, "--install", "--target=claude")
 	require.Error(t, err, "conflict must exit non-zero")
 	assert.Contains(t, out, "conflict")
 
@@ -173,14 +180,14 @@ func TestSkillInstallConflictWithoutForce(t *testing.T) {
 }
 
 func TestSkillInstallForceOverwrites(t *testing.T) {
-	home := sandboxHome(t, true)
-	_, err := runSkill(t, "--install", "--agent=claude")
+	home := sandboxHome(t, "claude")
+	_, err := runSkill(t, "--install", "--target=claude")
 	require.NoError(t, err)
 
 	target := filepath.Join(home, ".claude", "skills", "notes", "SKILL.md")
 	require.NoError(t, os.WriteFile(target, []byte("local changes"), 0o644))
 
-	out, err := runSkill(t, "--install", "--agent=claude", "--force")
+	out, err := runSkill(t, "--install", "--target=claude", "--force")
 	require.NoError(t, err)
 	assert.Contains(t, out, "overwrite")
 
@@ -190,8 +197,8 @@ func TestSkillInstallForceOverwrites(t *testing.T) {
 }
 
 func TestSkillInstallDryRun(t *testing.T) {
-	home := sandboxHome(t, true)
-	out, err := runSkill(t, "--install", "--agent=claude", "--dry-run")
+	home := sandboxHome(t, "claude")
+	out, err := runSkill(t, "--install", "--target=claude", "--dry-run")
 	require.NoError(t, err)
 	assert.Contains(t, out, "would create")
 
@@ -201,7 +208,7 @@ func TestSkillInstallDryRun(t *testing.T) {
 }
 
 func TestSkillInstallAutoDetectFindsClaude(t *testing.T) {
-	home := sandboxHome(t, true)
+	home := sandboxHome(t, "claude")
 	out, err := runSkill(t, "--install")
 	require.NoError(t, err)
 	assert.Contains(t, out, "create")
@@ -212,59 +219,76 @@ func TestSkillInstallAutoDetectFindsClaude(t *testing.T) {
 }
 
 func TestSkillInstallAutoDetectNoneFound(t *testing.T) {
-	sandboxHome(t, false)
+	sandboxHome(t)
 	_, err := runSkill(t, "--install")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no supported agent detected")
+	assert.Contains(t, err.Error(), "no supported target detected")
 	assert.Contains(t, err.Error(), "claude")
 }
 
-func TestSkillInstallMissingParentDirectoryErrors(t *testing.T) {
-	sandboxHome(t, false) // no ~/.claude/skills
-	_, err := runSkill(t, "--install", "--agent=claude")
+func TestSkillInstallMissingRootDirectoryErrors(t *testing.T) {
+	sandboxHome(t) // no ~/.claude/skills
+	_, err := runSkill(t, "--install", "--target=claude")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "agent skills directory not found")
+	assert.Contains(t, err.Error(), "skills root directory not found")
 }
 
-func TestSkillInstallMultipleAgents(t *testing.T) {
-	home := sandboxHome(t, true)
-
-	fakeDir := filepath.Join(home, ".fake", "skills")
-	require.NoError(t, os.MkdirAll(fakeDir, 0o755))
-
-	prev := agents
-	agents = append(append([]agentTarget{}, agents...), agentTarget{
-		Name: "fake",
-		PathFor: func() (string, error) {
-			h, err := homeDir()
-			if err != nil {
-				return "", err
-			}
-			return filepath.Join(h, ".fake", "skills", "notes", "SKILL.md"), nil
-		},
-		Detect: func() (bool, error) {
-			h, err := homeDir()
-			if err != nil {
-				return false, err
-			}
-			_, statErr := os.Stat(filepath.Join(h, ".fake", "skills"))
-			return statErr == nil, nil
-		},
-	})
-	t.Cleanup(func() { agents = prev })
+func TestSkillInstallAllTargetsAutoDetect(t *testing.T) {
+	home := sandboxHome(t, "claude", "pi", "agents")
 
 	out, err := runSkill(t, "--install")
 	require.NoError(t, err)
-	assert.Contains(t, out, "claude")
-	assert.Contains(t, out, "fake")
-	assert.FileExists(t, filepath.Join(home, ".claude", "skills", "notes", "SKILL.md"))
-	assert.FileExists(t, filepath.Join(home, ".fake", "skills", "notes", "SKILL.md"))
+	for _, name := range []string{"claude", "pi", "agents"} {
+		assert.Contains(t, out, name)
+	}
+
+	for _, p := range []string{
+		filepath.Join(home, ".claude", "skills", "notes", "SKILL.md"),
+		filepath.Join(home, ".pi", "agent", "skills", "notes", "SKILL.md"),
+		filepath.Join(home, ".agents", "skills", "notes", "SKILL.md"),
+	} {
+		assert.FileExists(t, p)
+	}
 }
 
-func TestSkillHelpDocumentsAgents(t *testing.T) {
+func TestSkillInstallEachTargetExplicit(t *testing.T) {
+	cases := []struct {
+		name string
+		path []string
+	}{
+		{"claude", []string{".claude", "skills", "notes", "SKILL.md"}},
+		{"pi", []string{".pi", "agent", "skills", "notes", "SKILL.md"}},
+		{"agents", []string{".agents", "skills", "notes", "SKILL.md"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := sandboxHome(t, tc.name)
+			out, err := runSkill(t, "--install", "--target="+tc.name)
+			require.NoError(t, err)
+			assert.Contains(t, out, "create")
+
+			target := filepath.Join(append([]string{home}, tc.path...)...)
+			assert.FileExists(t, target)
+		})
+	}
+}
+
+func TestSkillHelpDocumentsTargets(t *testing.T) {
 	out, err := runSkill(t, "--help")
 	require.NoError(t, err)
-	assert.Contains(t, out, "Supported --agent values:")
-	assert.Contains(t, out, "claude")
-	assert.Contains(t, out, "~/.claude/skills/notes/SKILL.md")
+	assert.Contains(t, out, "Supported --target values:")
+	for _, fragment := range []string{
+		"claude",
+		"~/.claude/skills/notes/SKILL.md",
+		"Claude Code",
+		"pi",
+		"~/.pi/agent/skills/notes/SKILL.md",
+		"Pi",
+		"agents",
+		"~/.agents/skills/notes/SKILL.md",
+		"Codex",
+		"agentskills.io/specification",
+	} {
+		assert.Contains(t, out, fragment)
+	}
 }


### PR DESCRIPTION
## Summary

`notes skill --install` gains two new install targets alongside `claude`, with the install flag renamed from `--agent` to `--target` since each target names a **filesystem location** (a skills root directory), not an agent — multiple harnesses read from the same locations.

| Target    | Path                                       | Read by                                                                |
|-----------|--------------------------------------------|------------------------------------------------------------------------|
| `claude`  | `~/.claude/skills/notes/SKILL.md`          | Claude Code                                                            |
| `pi`      | `~/.pi/agent/skills/notes/SKILL.md`        | Pi                                                                     |
| `agents`  | `~/.agents/skills/notes/SKILL.md`          | Codex, Cursor, OpenCode, Pi, VS Code Copilot, Warp, and other harnesses adopting the cross-harness convention |

All targets share the [Agent Skills](https://agentskills.io/specification) `SKILL.md` format. Three writes cover every major harness on the market today (single write to `~/.agents/skills/` reaches six harnesses).

Auto-detect (`notes skill --install` with no `--target`) writes to every target whose skills-root directory exists. Pass `--target=<name>` to install into a single one.

Internally, `installTarget` declares an explicit `RootDir`. `planOne` short-circuits with an actionable error if the root is missing, so `writeSkillFile` no longer special-cases per-layout — adding a new target is a single struct literal.

Patch bump to `0.4.2`. The `--agent` flag was added in 0.4.1; the rename is a breaking change within a patch release, but `0.4.1` only shipped `--agent=claude` so there is no realistic in-the-wild script breakage.

Sources for path conventions: [Claude](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview), [Codex](https://developers.openai.com/codex/skills), [Cursor](https://cursor.com/docs/skills), [OpenCode](https://opencode.ai/docs/skills/), [Pi](https://pi.dev/docs/latest/skills), [VS Code Copilot](https://code.visualstudio.com/docs/copilot/customization/agent-skills), [Warp](https://docs.warp.dev/agent-platform/capabilities/skills/).

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only
