### PR TITLE
Add public filter to ls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- `notes ls --public` filters the list to notes whose frontmatter sets `public: true` ([#284]).
+
+[#284]: https://github.com/dreikanter/notes/pull/284
+
 ## [0.4.2] - 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ notes ls --type todo
 notes ls --slug meeting
 notes ls --tag work
 notes ls --tag work --tag meeting     # multiple --tag flags are ANDed
+notes ls --public
 notes ls --today
 
 # Resolve a note and print its absolute path (exactly one lookup flag, or none)

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -18,13 +18,14 @@ var lsCmd = &cobra.Command{
 		slug, _ := cmd.Flags().GetString("slug")
 		tags, _ := cmd.Flags().GetStringSlice("tag")
 		today, _ := cmd.Flags().GetBool("today")
+		publicOnly, _ := cmd.Flags().GetBool("public")
 
 		store, err := notesStore()
 		if err != nil {
 			return err
 		}
 
-		ids, err := lsIDs(store, noteType, slug, tags, today)
+		ids, err := lsIDs(store, noteType, slug, tags, today, publicOnly)
 		if err != nil {
 			return err
 		}
@@ -43,8 +44,8 @@ var lsCmd = &cobra.Command{
 // lsIDs returns the IDs to print. With no filter flags it takes the fast
 // directory-scan path via Store.IDs; otherwise it builds a QueryOpt list
 // and delegates to Store.All.
-func lsIDs(store note.Store, noteType, slug string, tags []string, today bool) ([]int, error) {
-	if noteType == "" && slug == "" && len(tags) == 0 && !today {
+func lsIDs(store note.Store, noteType, slug string, tags []string, today, publicOnly bool) ([]int, error) {
+	if noteType == "" && slug == "" && len(tags) == 0 && !today && !publicOnly {
 		return store.IDs()
 	}
 	var opts []note.QueryOpt
@@ -59,6 +60,9 @@ func lsIDs(store note.Store, noteType, slug string, tags []string, today bool) (
 	}
 	if today {
 		opts = append(opts, note.WithExactDate(time.Now()))
+	}
+	if publicOnly {
+		opts = append(opts, note.WithPublic(true))
 	}
 	entries, err := store.All(opts...)
 	if err != nil {
@@ -77,6 +81,7 @@ func registerLsFlags() {
 	lsCmd.Flags().String("slug", "", "filter by exact slug")
 	lsCmd.Flags().StringSlice("tag", nil, "filter by tag (repeatable, all must match)")
 	lsCmd.Flags().Bool("today", false, "only list notes created today")
+	lsCmd.Flags().Bool("public", false, "only list public notes")
 }
 
 func init() {

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,8 +13,12 @@ import (
 
 func runLs(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	return runLsInRoot(t, testdataPath(t), args...)
+}
 
-	root := testdataPath(t)
+func runLsInRoot(t *testing.T, root string, args ...string) (string, error) {
+	t.Helper()
+
 	lsCmd.ResetFlags()
 	registerLsFlags()
 
@@ -34,6 +40,41 @@ func TestLsNoArgs(t *testing.T) {
 	for _, line := range lines {
 		assert.True(t, allDigits(line), "expected integer ID per line, got %q", line)
 	}
+}
+
+func TestLsPublicFilter(t *testing.T) {
+	root := copyTestdata(t)
+	markFixturePublic(t, root, "2026/01/20260106_8823_999.md")
+	markFixturePublic(t, root, "2026/01/20260102_8814.todo.md")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantIDs []string
+	}{
+		{name: "public", args: []string{"--public"}, wantIDs: []string{"8823", "8814"}},
+		{name: "public and tag", args: []string{"--public", "--tag", "planning"}, wantIDs: []string{"8814"}},
+		{name: "public and type", args: []string{"--public", "--type", "todo"}, wantIDs: []string{"8814"}},
+		{name: "public and tag no overlap", args: []string{"--public", "--tag", "meeting"}, wantIDs: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := runLsInRoot(t, root, tt.args...)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantIDs, outputLines(out))
+		})
+	}
+}
+
+func markFixturePublic(t *testing.T, root, rel string) {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	updated := strings.Replace(string(data), "---\n", "---\npublic: true\n", 1)
+	require.NotEqual(t, string(data), updated)
+	require.NoError(t, os.WriteFile(path, []byte(updated), 0o644))
 }
 
 func TestLsFilters(t *testing.T) {

--- a/internal/cli/skill.md
+++ b/internal/cli/skill.md
@@ -58,10 +58,11 @@ notes new-todo
 # Most recent IDs, newest first
 notes ls --limit 10
 
-# Filter by type, slug, or tag (--tag is repeatable; tags AND together)
+# Filter by type, slug, tag, or public status (--tag is repeatable; tags AND together)
 notes ls --type todo --limit 1
 notes ls --slug report
 notes ls --tag journal --tag idea
+notes ls --public
 
 # Only today's notes
 notes ls --today


### PR DESCRIPTION
## Summary

- Add `notes ls --public` using the existing `note.WithPublic(true)` query option
- Document the new flag and add an Unreleased changelog entry
- Cover standalone and composed public filters in CLI tests

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Closes #282
