### PR TITLE
Add JSON read output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-17
+
 ### Added
 
+- `notes read` accepts multiple IDs and adds `--json` output for machine-readable note records ([#285]).
 - `notes ls --public` filters the list to notes whose frontmatter sets `public: true` ([#284]).
 
 [#284]: https://github.com/dreikanter/notes/pull/284
+[#285]: https://github.com/dreikanter/notes/pull/285
 
 ## [0.4.2] - 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ notes resolve --type todo        # most recent note of that type
 notes resolve --slug meeting     # most recent note with that slug
 notes resolve --tag work         # most recent note with that tag
 
-# Read a note by numeric ID
+# Read one or more notes by numeric ID
 notes read 8823
+notes read 8823 8818
 notes read 8823 --no-frontmatter
+notes read 8823 8818 --json
 
 # Fill empty frontmatter (title, description, tags) using Claude Code CLI
 notes annotate 8823

--- a/internal/cli/read.go
+++ b/internal/cli/read.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -11,13 +12,13 @@ import (
 )
 
 var readCmd = &cobra.Command{
-	Use:   "read <id>",
-	Short: "Read a note",
-	Args:  cobra.ExactArgs(1),
+	Use:   "read <id> [id...]",
+	Short: "Read one or more notes",
+	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		id, err := strconv.Atoi(args[0])
+		ids, err := parseReadIDs(args)
 		if err != nil {
-			return fmt.Errorf("id must be an integer: %s", args[0])
+			return err
 		}
 
 		store, err := notesStore()
@@ -25,31 +26,112 @@ var readCmd = &cobra.Command{
 			return err
 		}
 
-		entry, err := store.Get(id)
+		entries, err := readEntries(store, ids)
 		if err != nil {
-			if errors.Is(err, note.ErrNotFound) {
-				return fmt.Errorf("note %d not found", id)
-			}
 			return err
 		}
 
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		if jsonOutput {
+			return writeReadJSON(cmd, entries)
+		}
+
+		noFrontmatter, _ := cmd.Flags().GetBool("no-frontmatter")
+		return writeReadMarkdown(cmd, store, entries, noFrontmatter)
+	},
+}
+
+type readJSONRecord struct {
+	ID          int      `json:"id"`
+	UID         string   `json:"uid"`
+	Title       string   `json:"title"`
+	Slug        string   `json:"slug"`
+	Tags        []string `json:"tags"`
+	Date        string   `json:"date"`
+	Description string   `json:"description"`
+	Public      bool     `json:"public"`
+	Body        string   `json:"body"`
+}
+
+func parseReadIDs(args []string) ([]int, error) {
+	ids := make([]int, len(args))
+	for i, arg := range args {
+		id, err := strconv.Atoi(arg)
+		if err != nil {
+			return nil, fmt.Errorf("id must be an integer: %s", arg)
+		}
+		ids[i] = id
+	}
+	return ids, nil
+}
+
+func readEntries(store *note.OSStore, ids []int) ([]note.Entry, error) {
+	entries := make([]note.Entry, len(ids))
+	for i, id := range ids {
+		entry, err := store.Get(id)
+		if err != nil {
+			if errors.Is(err, note.ErrNotFound) {
+				return nil, fmt.Errorf("note %d not found", id)
+			}
+			return nil, err
+		}
+		entries[i] = entry
+	}
+	return entries, nil
+}
+
+func writeReadMarkdown(cmd *cobra.Command, store *note.OSStore, entries []note.Entry, noFrontmatter bool) error {
+	out := cmd.OutOrStdout()
+	for _, entry := range entries {
 		data, err := os.ReadFile(store.AbsPath(entry))
 		if err != nil {
 			return err
 		}
-
-		noFrontmatter, _ := cmd.Flags().GetBool("no-frontmatter")
 		if noFrontmatter {
 			data = note.StripFrontmatter(data)
 		}
+		if _, err := out.Write(data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-		_, err = cmd.OutOrStdout().Write(data)
-		return err
-	},
+func writeReadJSON(cmd *cobra.Command, entries []note.Entry) error {
+	records := make([]readJSONRecord, len(entries))
+	for i, entry := range entries {
+		records[i] = readJSONRecord{
+			ID:          entry.ID,
+			UID:         entryUID(entry),
+			Title:       entry.Meta.Title,
+			Slug:        entry.Meta.Slug,
+			Tags:        jsonTags(entry.Meta.Tags),
+			Date:        entry.Meta.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			Description: entry.Meta.Description,
+			Public:      entry.Meta.Public,
+			Body:        entry.Body,
+		}
+	}
+	return json.NewEncoder(cmd.OutOrStdout()).Encode(records)
+}
+
+func entryUID(entry note.Entry) string {
+	if entry.UID != "" {
+		return entry.UID
+	}
+	return note.UID(entry.Meta.CreatedAt.Format(note.DateFormat), entry.ID)
+}
+
+func jsonTags(tags []string) []string {
+	if tags == nil {
+		return []string{}
+	}
+	return tags
 }
 
 func registerReadFlags() {
-	readCmd.Flags().Bool("no-frontmatter", false, "exclude YAML frontmatter from output")
+	readCmd.Flags().Bool("no-frontmatter", false, "exclude YAML frontmatter from Markdown output")
+	readCmd.Flags().Bool("json", false, "emit notes as a JSON array")
 }
 
 func init() {

--- a/internal/cli/read_test.go
+++ b/internal/cli/read_test.go
@@ -2,6 +2,9 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,8 +14,11 @@ import (
 
 func runRead(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	return runReadInRoot(t, testdataPath(t), args...)
+}
 
-	root := testdataPath(t)
+func runReadInRoot(t *testing.T, root string, args ...string) (string, error) {
+	t.Helper()
 
 	readCmd.ResetFlags()
 	registerReadFlags()
@@ -32,15 +38,35 @@ func TestReadByID(t *testing.T) {
 	assert.Contains(t, out, "Plain note")
 }
 
+func TestReadMultipleIDs(t *testing.T) {
+	out, err := runRead(t, "8823", "8818")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Plain note")
+	assert.Contains(t, out, "Standup notes")
+	assert.Less(t, strings.Index(out, "Plain note"), strings.Index(out, "Standup notes"))
+}
+
 func TestReadMissingID(t *testing.T) {
 	_, err := runRead(t, "999999")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestReadMissingIDAmongMany(t *testing.T) {
+	_, err := runRead(t, "8823", "999999")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "note 999999 not found")
+}
+
 func TestReadNonIntegerArg(t *testing.T) {
 	_, err := runRead(t, "not-an-id")
 	require.Error(t, err)
+}
+
+func TestReadNonIntegerArgAmongMany(t *testing.T) {
+	_, err := runRead(t, "8823", "not-an-id")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "id must be an integer: not-an-id")
 }
 
 func TestReadNoArgsErrors(t *testing.T) {
@@ -54,4 +80,88 @@ func TestReadNoFrontmatter(t *testing.T) {
 	// Frontmatter should be stripped; "tags:" should not appear
 	assert.NotContains(t, out, "tags:")
 	assert.Contains(t, out, "Standup notes")
+}
+
+func TestReadNoFrontmatterMultipleIDs(t *testing.T) {
+	out, err := runRead(t, "8818", "8814", "--no-frontmatter")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "tags:")
+	assert.Contains(t, out, "Standup notes")
+	assert.Contains(t, out, "Todo")
+}
+
+func TestReadJSON(t *testing.T) {
+	out, err := runRead(t, "8818", "--json")
+	require.NoError(t, err)
+
+	var records []readJSONRecord
+	require.NoError(t, json.Unmarshal([]byte(out), &records))
+	require.Len(t, records, 1)
+
+	record := records[0]
+	assert.Equal(t, 8818, record.ID)
+	assert.Equal(t, "20260104_8818", record.UID)
+	assert.Equal(t, "meeting", record.Slug)
+	assert.Equal(t, []string{"meeting", "work"}, record.Tags)
+	assert.Equal(t, "2026-01-04T00:00:00Z", record.Date)
+	assert.False(t, record.Public)
+	assert.Contains(t, record.Body, "Standup notes")
+	assert.NotContains(t, record.Body, "tags:")
+}
+
+func TestReadJSONMultipleIDs(t *testing.T) {
+	out, err := runRead(t, "8823", "8814", "--json")
+	require.NoError(t, err)
+
+	var records []readJSONRecord
+	require.NoError(t, json.Unmarshal([]byte(out), &records))
+	require.Len(t, records, 2)
+	assert.Equal(t, []int{8823, 8814}, []int{records[0].ID, records[1].ID})
+	assert.Equal(t, "20260106_8823", records[0].UID)
+	assert.Equal(t, "20260102_8814", records[1].UID)
+	assert.Contains(t, records[0].Body, "Plain note")
+	assert.Contains(t, records[1].Body, "Todo")
+}
+
+func TestReadUsesFilenamePathWhenFrontmatterDateDiffers(t *testing.T) {
+	root := copyTestdata(t)
+	writeFixtureDate(t, root, "2026-02-01")
+
+	out, err := runReadInRoot(t, root, "8818")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Standup notes")
+}
+
+func TestReadJSONUIDUsesFilenameDateWhenFrontmatterDateDiffers(t *testing.T) {
+	root := copyTestdata(t)
+	writeFixtureDate(t, root, "2026-02-01")
+
+	out, err := runReadInRoot(t, root, "8818", "--json")
+	require.NoError(t, err)
+
+	var records []readJSONRecord
+	require.NoError(t, json.Unmarshal([]byte(out), &records))
+	require.Len(t, records, 1)
+	assert.Equal(t, "20260104_8818", records[0].UID)
+	assert.Equal(t, "2026-02-01T00:00:00Z", records[0].Date)
+}
+
+func writeFixtureDate(t *testing.T, root, date string) {
+	t.Helper()
+	path := filepath.Join(root, "2026/01/20260104_8818_meeting.md")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	updated := strings.Replace(string(data), "---\n", "---\ndate: "+date+"\n", 1)
+	require.NoError(t, os.WriteFile(path, []byte(updated), 0o644))
+}
+
+func TestReadJSONNoTagsUsesEmptyArray(t *testing.T) {
+	out, err := runRead(t, "6973", "--json")
+	require.NoError(t, err)
+
+	var raw []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &raw))
+	tags, ok := raw[0]["tags"].([]any)
+	require.True(t, ok)
+	assert.Empty(t, tags)
 }

--- a/internal/cli/skill.md
+++ b/internal/cli/skill.md
@@ -72,10 +72,12 @@ notes ls --today
 
 ```sh
 notes read 8823
+notes read 8823 8818
 notes read 8823 --no-frontmatter
+notes read 8823 8818 --json
 ```
 
-`notes read` requires a numeric ID. Compose with `ls` or `resolve` to read a filtered note:
+`notes read` requires one or more numeric IDs. Use `--json` to emit a JSON array containing parsed metadata and Markdown body. Compose with `ls` or `resolve` to read filtered notes:
 
 ```sh
 # Read the most recent todo

--- a/note/domain.go
+++ b/note/domain.go
@@ -5,6 +5,7 @@ import "time"
 // Entry is the single domain object that Store implementations work with.
 type Entry struct {
 	ID   int
+	UID  string // stable filename-derived reference: YYYYMMDD_ID
 	Meta Meta
 	Body string
 }

--- a/note/mem_store.go
+++ b/note/mem_store.go
@@ -101,6 +101,9 @@ func (s *MemStore) Put(entry Entry) (Entry, error) {
 	if entry.Meta.CreatedAt.IsZero() {
 		return Entry{}, fmt.Errorf("note %d: CreatedAt is zero", entry.ID)
 	}
+	if entry.UID == "" {
+		entry.UID = UID(entry.Meta.CreatedAt.Format(DateFormat), entry.ID)
+	}
 	entry.Meta.UpdatedAt = now
 	s.entries[entry.ID] = entry
 	return entry, nil

--- a/note/note.go
+++ b/note/note.go
@@ -101,12 +101,23 @@ func ParseFilename(baseName string) (ref, error) {
 	}, nil
 }
 
+// UID returns the stable filename-derived reference for date and id.
+func UID(date string, id int) string {
+	return fmt.Sprintf("%s_%d", date, id)
+}
+
+// UIDDate returns the date prefix from uid.
+func UIDDate(uid string) (string, bool) {
+	date, _, ok := strings.Cut(uid, "_")
+	return date, ok && len(date) >= 5 && IsDigits(date)
+}
+
 // Filename generates a note filename from date, id, optional slug, and optional type.
 // Type is encoded as a secondary file extension (e.g. ".todo.md") only when it's
 // safe to round-trip through ParseFilename; values with '.' or path separators
 // are omitted from the filename, with frontmatter remaining canonical.
 func Filename(date string, id int, slug, noteType string) string {
-	base := fmt.Sprintf("%s_%d", date, id)
+	base := UID(date, id)
 	if slug != "" {
 		base = fmt.Sprintf("%s_%s", base, slug)
 	}

--- a/note/os_store.go
+++ b/note/os_store.go
@@ -346,6 +346,7 @@ func (s *OSStore) readEntry(r fileRef) (Entry, error) {
 	meta := frontmatterToMeta(fm, r, info.ModTime(), body)
 	return Entry{
 		ID:   r.id,
+		UID:  UID(r.date, r.id),
 		Meta: meta,
 		Body: string(body),
 	}, nil
@@ -438,20 +439,28 @@ func (s *OSStore) Put(entry Entry) (Entry, error) {
 	}
 
 	entry.Meta.UpdatedAt = now
+	entry.UID = UID(entry.Meta.CreatedAt.Format(DateFormat), entry.ID)
 	return entry, nil
 }
 
 // AbsPath returns the absolute path the store would use for entry given its
-// current Meta.CreatedAt, ID, and Meta.Slug. It derives the path purely from
-// the entry's fields — no I/O.
+// current UID (or Meta.CreatedAt when UID is empty), ID, Slug, and Type. It
+// derives the path purely from the entry's fields — no I/O.
 func (s *OSStore) AbsPath(entry Entry) string {
-	_, abs := s.pathFor(entry)
+	date := entry.Meta.CreatedAt.Format(DateFormat)
+	if uidDate, ok := UIDDate(entry.UID); ok {
+		date = uidDate
+	}
+	_, abs := s.pathForDate(entry, date)
 	return abs
 }
 
 // pathFor returns the rel/abs path the filename layout produces for entry.
 func (s *OSStore) pathFor(entry Entry) (rel, abs string) {
-	date := entry.Meta.CreatedAt.Format(DateFormat)
+	return s.pathForDate(entry, entry.Meta.CreatedAt.Format(DateFormat))
+}
+
+func (s *OSStore) pathForDate(entry Entry, date string) (rel, abs string) {
 	name := Filename(date, entry.ID, entry.Meta.Slug, entry.Meta.Type)
 	dir := DirPath(s.root, date)
 	abs = filepath.Join(dir, name)


### PR DESCRIPTION
## Summary

- Allow `notes read` to accept multiple IDs in one invocation
- Add `notes read --json` output with ID, UID, parsed metadata, and Markdown body records
- Document the new read forms and move the changelog to a 0.5.0 minor release heading

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Closes #283
